### PR TITLE
Fix #24: Turn down PMD logging on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ install:
   - mvn -s src/test/resources/settings.xml -q package -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -B -V
 
 script:
-  - mvn -s src/test/resources/settings.xml verify
+  - >
+    mvn -s src/test/resources/settings.xml help:active-profiles verify \
+      -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error \
 
 after_success:
   - chmod 755 src/main/tools/travis/*


### PR DESCRIPTION
* Turn down PMD deprecation warnings when building on Travis
* Output active Maven profile information on Travis builds