### PR TITLE
Change property order of manifest serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>3.8.2</version>
+    <version>3.8.6</version>
   </parent>
 
 </project>

--- a/src/main/java/info/freelibrary/iiif/presentation/Collection.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Collection.java
@@ -159,8 +159,8 @@ public class Collection extends Resource<Collection> {
     /**
      * Sets the manifests associated with this collection. 544
      *
-     * @param aManifestList
-     * @return
+     * @param aManifestList A list of manifests
+     * @return This collection
      */
     @JsonSetter(Constants.MANIFESTS)
     public Collection setManifests(final List<Manifest> aManifestList) {

--- a/src/main/java/info/freelibrary/iiif/presentation/Manifest.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Manifest.java
@@ -12,6 +12,8 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import info.freelibrary.iiif.presentation.properties.Description;
@@ -35,6 +37,10 @@ import io.vertx.core.json.jackson.DatabindCodec;
  * descriptive information about the object or the intellectual work that it conveys. Each manifest describes how to
  * present a single object such as a book, a photograph, or a statue.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonPropertyOrder({ Constants.CONTEXT, Constants.ID, Constants.TYPE, Constants.LABEL, Constants.VIEWING_HINT,
+    Constants.VIEWING_DIRECTION, Constants.DESCRIPTION, Constants.ATTRIBUTION, Constants.LICENSE, Constants.WITHIN,
+    Constants.LOGO, Constants.THUMBNAIL, Constants.METADATA, Constants.SEQUENCES, Constants.SERVICE })
 public class Manifest extends Resource<Manifest> {
 
     static {

--- a/src/main/java/info/freelibrary/iiif/presentation/Sequence.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Sequence.java
@@ -43,6 +43,8 @@ public class Sequence extends Resource<Sequence> {
 
     /**
      * Creates a IIIF presentation sequence resource with the supplied ID.
+     *
+     * @param aID An ID
      */
     public Sequence(final String aID) {
         super(TYPE, REQ_ARG_COUNT);
@@ -52,6 +54,8 @@ public class Sequence extends Resource<Sequence> {
 
     /**
      * Creates a IIIF presentation sequence resource with the supplied ID.
+     *
+     * @param aID An ID
      */
     public Sequence(final URI aID) {
         super(TYPE, REQ_ARG_COUNT);

--- a/src/main/tools/checkstyle/checkstyle.xml
+++ b/src/main/tools/checkstyle/checkstyle.xml
@@ -47,8 +47,6 @@
     </module>
     <module name="JavadocMethod">
       <property name="scope" value="public" />
-      <property name="allowMissingParamTags" value="true" />
-      <property name="allowMissingReturnTag" value="true" />
     </module>
     <module name="NeedBraces" />
     <module name="LeftCurly" />

--- a/src/main/tools/pmd/pmd-rules.xml
+++ b/src/main/tools/pmd/pmd-rules.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Custom ruleset" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
   <description>FreeLibrary PMD Rules</description>
 

--- a/src/test/java/info/freelibrary/iiif/presentation/ManifestTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/ManifestTest.java
@@ -17,7 +17,10 @@ import org.junit.Test;
 import com.opencsv.CSVReader;
 
 import info.freelibrary.iiif.presentation.properties.Metadata;
+import info.freelibrary.iiif.presentation.properties.ViewingDirection;
+import info.freelibrary.iiif.presentation.properties.ViewingHint;
 import info.freelibrary.iiif.presentation.services.ImageInfoService;
+import info.freelibrary.iiif.presentation.utils.Constants;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -129,6 +132,32 @@ public class ManifestTest extends AbstractTest {
 
         sequence.addCanvas(canvas1, canvas2);
         myVertx = Vertx.factory.vertx();
+    }
+
+    /**
+     * Test the order of the properties that come out of manifest serialization.
+     */
+    @Test
+    public void testOrder() {
+        final Manifest manifest = new Manifest(MANIFEST_URI, TEST_TITLE);
+        final String[] names;
+
+        // Construct a simple manifest
+        manifest.setViewingHint(ViewingHint.Option.INDIVIDUALS);
+        manifest.setViewingDirection(ViewingDirection.RIGHT_TO_LEFT);
+        manifest.addSequence(new Sequence());
+
+        // Get the order of the names from serialization
+        names = new JsonObject(manifest.toString()).fieldNames().toArray(new String[] {});
+
+        // Test that the order is the same
+        assertEquals(Constants.CONTEXT, names[0]);
+        assertEquals(Constants.ID, names[1]);
+        assertEquals(Constants.TYPE, names[2]);
+        assertEquals(Constants.LABEL, names[3]);
+        assertEquals(Constants.VIEWING_HINT, names[4]);
+        assertEquals(Constants.VIEWING_DIRECTION, names[5]);
+        assertEquals(Constants.SEQUENCES, names[6]);
     }
 
     /**

--- a/src/test/resources/json/z1960050.json
+++ b/src/test/resources/json/z1960050.json
@@ -1,8 +1,8 @@
 {
   "@context" : "http://iiif.io/api/presentation/2/context.json",
-  "label" : "Georgian NF Fragment 68a",
   "@id" : "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1960050/manifest",
   "@type" : "sc:Manifest",
+  "label" : "Georgian NF Fragment 68a",
   "logo" : "https://sinai-images.library.ucla.edu/images/logos/iiif_logo.png",
   "thumbnail" : "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1d79t3q/0,1022,6132,6132/150,150/0/default.jpg",
   "metadata" : [ {


### PR DESCRIPTION
Had a request to change the serialization order. This is just a first pass at that, not a comprehensive serialization re-ordering.

* Reorder viewingHint, viewingDirection, id, label, and type in manifest serialization
* Update parent project version to get new pmd-rules XSD and new Checkstyle rules
* Update Javadocs that the newer Checkstyle rules complained about
* Update tests to align them with the new property order