### PR TITLE
[JPA-96] Fix various bugs

### DIFF
--- a/src/main/java/info/freelibrary/iiif/presentation/v3/Manifest.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/Manifest.java
@@ -50,17 +50,17 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
 
     private final List<URI> myContexts = Stream.of(Constants.CONTEXT_URI).collect(Collectors.toList());
 
-    private final List<Canvas> myCanvases = new ArrayList<>();
-
     private Optional<AccompanyingCanvas> myAccompanyingCanvas;
 
     private Optional<PlaceholderCanvas> myPlaceholderCanvas;
 
-    private Optional<Range> myRange = Optional.empty();
-
-    private Optional<StartCanvas> myStartCanvas = Optional.empty();
+    private Optional<StartCanvas> myStartCanvas;
 
     private ViewingDirection myViewingDirection;
+
+    private List<Canvas> myCanvases;
+
+    private List<Range> myRanges;
 
     /**
      * Creates a new manifest.
@@ -105,7 +105,7 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      * @param aProvider A resource provider
      */
     public Manifest(final String aID, final String aLabel, final List<Metadata> aMetadataList, final String aSummary,
-            final Thumbnail aThumbnail, final Provider aProvider) {
+        final Thumbnail aThumbnail, final Provider aProvider) {
         super(ResourceTypes.MANIFEST, aID, aLabel, aMetadataList, aSummary, aThumbnail, aProvider);
     }
 
@@ -120,7 +120,7 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      * @param aProvider A resource provider
      */
     public Manifest(final String aID, final Label aLabel, final List<Metadata> aMetadataList, final String aSummary,
-            final Thumbnail aThumbnail, final Provider aProvider) {
+        final Thumbnail aThumbnail, final Provider aProvider) {
         this(URI.create(aID), aLabel, aMetadataList, new Summary(aSummary), aThumbnail, aProvider);
     }
 
@@ -135,7 +135,7 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      * @param aProvider A resource provider
      */
     public Manifest(final URI aID, final Label aLabel, final List<Metadata> aMetadataList, final Summary aSummary,
-            final Thumbnail aThumbnail, final Provider aProvider) {
+        final Thumbnail aThumbnail, final Provider aProvider) {
         super(ResourceTypes.MANIFEST, aID, aLabel, aMetadataList, aSummary, aThumbnail, aProvider);
     }
 
@@ -150,7 +150,7 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      * @param aProvider A resource provider
      */
     public Manifest(final String aID, final Label aLabel, final List<Metadata> aMetadataList, final Summary aSummary,
-            final Thumbnail aThumbnail, final Provider aProvider) {
+        final Thumbnail aThumbnail, final Provider aProvider) {
         super(ResourceTypes.MANIFEST, URI.create(aID), aLabel, aMetadataList, aSummary, aThumbnail, aProvider);
     }
 
@@ -387,17 +387,19 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      * @param aCanvasArray An array of canvases to add to the manifest
      * @return The manifest
      */
-    public Manifest addCanvas(final Canvas... aCanvasArray) {
-        Objects.requireNonNull(aCanvasArray, MessageCodes.JPA_008);
+    public Manifest addCanvases(final Canvas... aCanvasArray) {
+        Collections.addAll(getCanvases(), aCanvasArray);
+        return this;
+    }
 
-        for (final Canvas canvas : aCanvasArray) {
-            Objects.requireNonNull(canvas, MessageCodes.JPA_008);
-
-            if (!myCanvases.add(canvas)) {
-                throw new UnsupportedOperationException(LOGGER.getMessage(MessageCodes.JPA_051, canvas));
-            }
-        }
-
+    /**
+     * Adds one or more ranges to the manifest.
+     *
+     * @param aRangeArray An array of ranges to add to the manifest
+     * @return The manifest
+     */
+    public Manifest addRanges(final Range... aRangeArray) {
+        Collections.addAll(getRanges(), aRangeArray);
         return this;
     }
 
@@ -408,6 +410,10 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      */
     @JsonGetter(Constants.ITEMS)
     public List<Canvas> getCanvases() {
+        if (myCanvases == null) {
+            myCanvases = new ArrayList<>();
+        }
+
         return myCanvases;
     }
 
@@ -419,8 +425,8 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      */
     @JsonGetter(Constants.ITEMS)
     public Manifest setCanvases(final Canvas... aCanvasArray) {
-        myCanvases.clear();
-        return addCanvas(aCanvasArray);
+        getCanvases().clear();
+        return addCanvases(aCanvasArray);
     }
 
     /**
@@ -442,29 +448,37 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      */
     @JsonGetter(Constants.START)
     public Optional<StartCanvas> getStartCanvas() {
+        if (myStartCanvas == null) {
+            myStartCanvas = Optional.empty();
+        }
+
         return myStartCanvas;
     }
 
     /**
-     * Gets the manifest's range.
+     * Gets the manifest's range(s).
      *
-     * @return The manifest's range
+     * @return The manifest's ranges
      */
     @JsonGetter(Constants.STRUCTURES)
-    public Optional<Range> getRange() {
-        return myRange;
+    public List<Range> getRanges() {
+        if (myRanges == null) {
+            myRanges = new ArrayList<>();
+        }
+
+        return myRanges;
     }
 
     /**
-     * Sets the manifest's range.
+     * Sets the manifest's range(s).
      *
-     * @param aRange A range to set in the manifest
+     * @param aRangeArray An array of ranges to set in the manifest
      * @return The manifest
      */
     @JsonSetter(Constants.STRUCTURES)
-    public Manifest setRange(final Range aRange) {
-        myRange = Optional.ofNullable(aRange);
-        return this;
+    public Manifest setRanges(final Range... aRangeArray) {
+        getRanges().clear();
+        return addRanges(aRangeArray);
     }
 
     @Override

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/Manifest.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/Manifest.java
@@ -430,6 +430,22 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
     }
 
     /**
+     * Sets the manifest's canvases from the contents of a list.
+     *
+     * @param aCanvasList A list of canvases to be set in the manifest
+     * @return The manifest
+     */
+    @JsonIgnore
+    public Manifest setCanvases(final List<Canvas> aCanvasList) {
+        final List<Canvas> canvases = getCanvases();
+
+        canvases.clear();
+        canvases.addAll(aCanvasList);
+
+        return this;
+    }
+
+    /**
      * Sets the optional start canvas.
      *
      * @param aStartCanvas A start canvas
@@ -479,6 +495,22 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
     public Manifest setRanges(final Range... aRangeArray) {
         getRanges().clear();
         return addRanges(aRangeArray);
+    }
+
+    /**
+     * Sets the manifest's ranges from the contents of a list.
+     *
+     * @param aRangeList A list of ranges to be set in the manifest
+     * @return The manifest
+     */
+    @JsonIgnore
+    public Manifest setRanges(final List<Range> aRangeList) {
+        final List<Range> ranges = getRanges();
+
+        ranges.clear();
+        ranges.addAll(aRangeList);
+
+        return this;
     }
 
     @Override

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/ResourceTypes.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/ResourceTypes.java
@@ -43,6 +43,10 @@ public final class ResourceTypes {
 
     public static final String IMAGE_SERVICE_3 = "ImageService3";
 
+    public static final String PHYSICAL_DIMS_SERVICE = "PhysicalDimsService";
+
+    public static final String GEO_JSON_SERVICE = "GeoJSONService";
+
     private ResourceTypes() {
         super();
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/id/DefaultMinter.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/id/DefaultMinter.java
@@ -8,7 +8,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -47,9 +46,9 @@ class DefaultMinter implements Minter {
     private static final String PAGE_ID_TEMPLATE = "{}/anno-page-{}";
 
     // All the alpha-numeric characters we use in creating NOIDs; lower case L is not used because it looks like "1"
-    private static final Character[] CHARS = new Character[] { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-        'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '1', '2', '3', '4', '5', '6', '7', '8',
-        '9', '0' };
+    private static final Character[] CHARS =
+        new Character[] { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+            'u', 'v', 'w', 'x', 'y', 'z', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' };
 
     /* The maximum number of NOIDs, given the size of our character array. */
     private static final int MAX_NOID_COUNT = 1500625;
@@ -200,6 +199,7 @@ class DefaultMinter implements Minter {
      *
      * @return The number of IDs that are available for use
      */
+    @Override
     public int remaining() {
         return NOIDS.size() - (myUsedNOIDs + myExistingIDs.size());
     }
@@ -233,7 +233,7 @@ class DefaultMinter implements Minter {
      */
     private void findPreexistingIDs(final Manifest aManifest) {
         final List<Canvas> canvases = aManifest.getCanvases();
-        final Optional<Range> range = aManifest.getRange();
+        final List<Range> ranges = aManifest.getRanges();
 
         for (final Canvas canvas : canvases) {
             if (!myExistingIDs.add(canvas.getID())) {
@@ -257,9 +257,9 @@ class DefaultMinter implements Minter {
             }
         }
 
-        range.ifPresent(rangeConsumer -> {
-            if (!myExistingIDs.add(rangeConsumer.getID())) {
-                LOGGER.warn(MessageCodes.JPA_100, rangeConsumer.getID());
+        ranges.forEach(range -> {
+            if (!myExistingIDs.add(range.getID())) {
+                LOGGER.warn(MessageCodes.JPA_100, range.getID());
             }
         });
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/AbstractImageService.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/AbstractImageService.java
@@ -13,7 +13,7 @@ import info.freelibrary.iiif.presentation.v3.Constants;
 /**
  * Abstract base class for image services.
  */
-@JsonPropertyOrder({ Constants.CONTEXT, Constants.TYPE, Constants.ID, Constants.PROFILE })
+@JsonPropertyOrder({ Constants.TYPE, Constants.ID, Constants.PROFILE })
 abstract class AbstractImageService implements ImageService {
 
     protected Profile myProfile;
@@ -99,16 +99,6 @@ abstract class AbstractImageService implements ImageService {
     @JsonSetter(Constants.ID)
     protected ImageService setID(final String aID) {
         return setID(URI.create(aID));
-    }
-
-    /**
-     * Sets the image service context.
-     *
-     * @param aContext The context
-     */
-    @JsonSetter(Constants.CONTEXT)
-    protected AbstractImageService setContext(final String aContext) {
-        return this;
     }
 
 }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/GenericService.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/GenericService.java
@@ -13,25 +13,26 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.MediaType;
 
-import info.freelibrary.iiif.presentation.v3.Constants;
-import info.freelibrary.iiif.presentation.v3.utils.MessageCodes;
 import info.freelibrary.util.FileUtils;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
+import info.freelibrary.iiif.presentation.v3.Constants;
+import info.freelibrary.iiif.presentation.v3.utils.MessageCodes;
+
 /**
  * A generic service class for other service implementations.
  */
-@JsonPropertyOrder({ Constants.CONTEXT, Constants.ID, Constants.PROFILE })
+@JsonPropertyOrder({ Constants.ID, Constants.TYPE, Constants.PROFILE })
 public class GenericService implements Service {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericService.class, MessageCodes.BUNDLE);
 
     private URI myID;
 
-    private URI myContext;
-
     private URI myProfile;
+
+    private final String myType;
 
     private Optional<MediaType> myFormat = Optional.ofNullable(null);
 
@@ -39,45 +40,28 @@ public class GenericService implements Service {
      * Creates a service for the supplied URI.
      *
      * @param aServiceID A service ID
+     * @param aType A service type
      */
-    public GenericService(final URI aServiceID) {
+    public GenericService(final URI aServiceID, final String aType) {
         myID = aServiceID;
+        myType = aType;
     }
 
     /**
      * Creates a service for the supplied ID.
      *
      * @param aServiceID A service ID in string form
+     * @param aType A service type
      */
-    public GenericService(final String aServiceID) {
+    public GenericService(final String aServiceID, final String aType) {
         myID = URI.create(aServiceID);
+        myType = aType;
     }
 
     @Override
-    public URI getContext() {
-        return myContext;
-    }
-
-    /**
-     * Sets the service's context.
-     *
-     * @param aContext The service's context
-     * @return This service
-     */
-    public GenericService setContext(final URI aContext) {
-        myContext = aContext;
-        return this;
-    }
-
-    /**
-     * Sets the service's context.
-     *
-     * @param aContext The service's context in string form
-     * @return This service
-     */
-    public GenericService setContext(final String aContext) {
-        myContext = URI.create(aContext);
-        return this;
+    @JsonGetter(Constants.TYPE)
+    public String getType() {
+        return myType;
     }
 
     /**
@@ -205,17 +189,17 @@ public class GenericService implements Service {
     @JsonValue
     private Object toJsonValue() {
         if (myID != null) {
-            if (myProfile == null && myContext == null && myFormat == null) {
+            if (myProfile == null && myFormat == null) {
                 return myID;
             } else {
                 final LinkedHashMap<String, Object> map = new LinkedHashMap<>();
 
-                if (myContext != null) {
-                    map.put(Constants.CONTEXT, myContext);
-                }
-
                 if (myID != null) {
                     map.put(Constants.ID, myID);
+                }
+
+                if (myType != null) {
+                    map.put(Constants.TYPE, myType);
                 }
 
                 if (myProfile != null) {

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/GeoJSONService.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/GeoJSONService.java
@@ -4,7 +4,6 @@ package info.freelibrary.iiif.presentation.v3.services;
 import java.net.URI;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import info.freelibrary.iiif.presentation.v3.Constants;
@@ -13,10 +12,6 @@ import info.freelibrary.iiif.presentation.v3.Constants;
  * An external service that provides GeoJSON information.
  */
 public class GeoJSONService implements Service {
-
-    /* The context for this service */
-    @JsonIgnore
-    public static final URI CONTEXT = URI.create("http://geojson.org/geojson-ld/geojson-context.jsonld");
 
     private URI myID;
 
@@ -27,12 +22,6 @@ public class GeoJSONService implements Service {
      */
     public GeoJSONService(final URI aID) {
         myID = aID;
-    }
-
-    @Override
-    @JsonGetter(Constants.CONTEXT)
-    public URI getContext() {
-        return CONTEXT;
     }
 
     /**
@@ -58,4 +47,14 @@ public class GeoJSONService implements Service {
         return this;
     }
 
+    /**
+     * Gets the service type.
+     *
+     * @return The type
+     */
+    @Override
+    @JsonGetter(Constants.TYPE)
+    public String getType() {
+        return getClass().getSimpleName();
+    }
 }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService.java
@@ -10,13 +10,6 @@ import java.net.URL;
 public interface ImageService extends Service {
 
     /**
-     * Gets the image service type.
-     *
-     * @return The type
-     */
-    String getType();
-
-    /**
      * Sets the image service ID.
      *
      * @param aID The ID

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService2.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService2.java
@@ -5,7 +5,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import info.freelibrary.util.I18nRuntimeException;
@@ -70,17 +69,6 @@ public class ImageService2 extends AbstractImageService implements ImageService 
      */
     @SuppressWarnings("unused")
     private ImageService2() {
-    }
-
-    /**
-     * Gets the service context.
-     *
-     * @return A service context
-     */
-    @Override
-    @JsonGetter(Constants.CONTEXT)
-    public URI getContext() {
-        return CONTEXT;
     }
 
     @Override
@@ -168,7 +156,7 @@ public class ImageService2 extends AbstractImageService implements ImageService 
             }
 
             throw new IllegalArgumentException(
-                    LOGGER.getMessage(MessageCodes.JPA_109, aProfile, ResourceTypes.IMAGE_SERVICE_2));
+                LOGGER.getMessage(MessageCodes.JPA_109, aProfile, ResourceTypes.IMAGE_SERVICE_2));
         }
     }
 

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService3.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService3.java
@@ -113,17 +113,17 @@ public class ImageService3 extends AbstractImageService implements ImageService 
         /**
          * http://iiif.io/api/image/3/level0.json
          */
-        LEVEL_ZERO("http://iiif.io/api/image/3/level0.json"),
+        LEVEL_ZERO("level0"),
 
         /**
          * http://iiif.io/api/image/3/level1.json
          */
-        LEVEL_ONE("http://iiif.io/api/image/3/level1.json"),
+        LEVEL_ONE("level1"),
 
         /**
          * http://iiif.io/api/image/3/level2.json
          */
-        LEVEL_TWO("http://iiif.io/api/image/3/level2.json");
+        LEVEL_TWO("level2");
 
         private static final Logger LOGGER = LoggerFactory.getLogger(ImageService3.Profile.class, MessageCodes.BUNDLE);
 
@@ -168,7 +168,7 @@ public class ImageService3 extends AbstractImageService implements ImageService 
             }
 
             throw new IllegalArgumentException(
-                    LOGGER.getMessage(MessageCodes.JPA_109, aProfile, ResourceTypes.IMAGE_SERVICE_3));
+                LOGGER.getMessage(MessageCodes.JPA_109, aProfile, ResourceTypes.IMAGE_SERVICE_3));
         }
     }
 

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService3.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService3.java
@@ -5,7 +5,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import info.freelibrary.util.I18nRuntimeException;
@@ -20,9 +19,6 @@ import info.freelibrary.iiif.presentation.v3.utils.MessageCodes;
  * A service that will return information about a particular image via IIIF Image API 3.
  */
 public class ImageService3 extends AbstractImageService implements ImageService {
-
-    /* The context for this service */
-    public static final URI CONTEXT = URI.create("http://iiif.io/api/image/3/context.json");
 
     /* The default profile level for the image info service */
     private static final ImageService3.Profile DEFAULT_LEVEL = ImageService3.Profile.LEVEL_TWO;
@@ -70,17 +66,6 @@ public class ImageService3 extends AbstractImageService implements ImageService 
      */
     @SuppressWarnings("unused")
     private ImageService3() {
-    }
-
-    /**
-     * Gets the service context.
-     *
-     * @return A service context
-     */
-    @Override
-    @JsonGetter(Constants.CONTEXT)
-    public URI getContext() {
-        return CONTEXT;
     }
 
     @Override

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/PhysicalDimsService.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/PhysicalDimsService.java
@@ -14,10 +14,6 @@ import info.freelibrary.iiif.presentation.v3.Constants;
  */
 public class PhysicalDimsService implements Service {
 
-    /* The context for this service */
-    @JsonIgnore
-    public static final URI CONTEXT = URI.create("http://iiif.io/api/annex/services/physdim/1/context.json");
-
     /* The profile for this service */
     @JsonIgnore
     public static final URI PROFILE = URI.create("http://iiif.io/api/annex/services/physdim");
@@ -50,12 +46,6 @@ public class PhysicalDimsService implements Service {
         myPhysicalUnits = aUnits;
     }
 
-    @Override
-    @JsonGetter(Constants.CONTEXT)
-    public URI getContext() {
-        return CONTEXT;
-    }
-
     /**
      * Get service profile.
      *
@@ -86,6 +76,17 @@ public class PhysicalDimsService implements Service {
     public PhysicalDimsService setID(final URI aID) {
         myID = aID;
         return this;
+    }
+
+    /**
+     * Gets the service type.
+     *
+     * @return The service type
+     */
+    @Override
+    @JsonGetter(Constants.TYPE)
+    public String getType() {
+        return getClass().getSimpleName();
     }
 
     /**

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/Service.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/Service.java
@@ -12,17 +12,16 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 public interface Service {
 
     /**
-     * Gets the service context. Required by ImageService, PhysicalDims; suggested by GeoJSON.
-     *
-     * @return A context
-     */
-    URI getContext();
-
-    /**
      * Gets the service ID.
      *
      * @return The ID
      */
     URI getID();
 
+    /**
+     * Gets the service type.
+     *
+     * @return The type
+     */
+    String getType();
 }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/ServiceDeserializer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/ServiceDeserializer.java
@@ -11,11 +11,12 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
 import info.freelibrary.iiif.presentation.v3.Constants;
 import info.freelibrary.iiif.presentation.v3.ResourceTypes;
 import info.freelibrary.iiif.presentation.v3.utils.MessageCodes;
-import info.freelibrary.util.Logger;
-import info.freelibrary.util.LoggerFactory;
 
 /**
  * Deserializes services from JSON documents into {@link Service} implementations.
@@ -49,19 +50,19 @@ public class ServiceDeserializer extends StdDeserializer<Service> {
      *
      */
     @Override
-    public Service deserialize(final JsonParser aParser, final DeserializationContext aContext) throws IOException,
-            JsonProcessingException {
+    public Service deserialize(final JsonParser aParser, final DeserializationContext aContext)
+            throws IOException, JsonProcessingException {
+
         final JsonNode node = aParser.getCodec().readTree(aParser);
         final Service service;
 
         if (node.isTextual()) {
-            service = new GenericService(node.textValue());
+            service = new GenericService(node.textValue(), GenericService.class.getSimpleName());
         } else if (node.isObject()) {
             final URI id = URI.create(node.get(Constants.ID).textValue());
             final JsonNode typeNode = node.get(Constants.TYPE);
-            final JsonNode contextNode = node.get(Constants.CONTEXT);
 
-            // Image services must have a type
+            // Services must have a type
             if (typeNode != null) {
                 final String type = typeNode.textValue();
 
@@ -75,15 +76,7 @@ public class ServiceDeserializer extends StdDeserializer<Service> {
                     final ImageService3.Profile level = ImageService3.Profile.fromString(profile);
 
                     service = new ImageService3(level, id);
-                } else {
-                    throw new JsonParseException(aParser,
-                            LOGGER.getMessage(MessageCodes.JPA_016, node.getClass().getName()),
-                            aParser.getCurrentLocation());
-                }
-            } else if (contextNode != null) {
-                final URI context = URI.create(contextNode.textValue());
-
-                if (PhysicalDimsService.CONTEXT.equals(context)) {
+                } else if (ResourceTypes.PHYSICAL_DIMS_SERVICE.equals(type)) {
                     final JsonNode scale = node.get(Constants.PHYSICAL_SCALE);
                     final JsonNode units = node.get(Constants.PHYSICAL_UNITS);
 
@@ -92,40 +85,30 @@ public class ServiceDeserializer extends StdDeserializer<Service> {
                     } else {
                         service = new PhysicalDimsService(id);
                     }
-                } else if (GeoJSONService.CONTEXT.equals(context)) {
+                } else if (ResourceTypes.GEO_JSON_SERVICE.equals(type)) {
                     service = new GeoJSONService(id);
                 } else {
                     final JsonNode profile = node.get(Constants.PROFILE);
                     final JsonNode format = node.get(Constants.FORMAT);
 
                     if (profile != null && format != null) {
-                        service = new GenericService(id).setContext(context).setProfile(profile.textValue()).setFormat(
-                                format.textValue());
+                        service =
+                            new GenericService(id, type).setProfile(profile.textValue()).setFormat(format.textValue());
                     } else if (profile != null) {
-                        service = new GenericService(id).setContext(context).setProfile(profile.textValue());
+                        service = new GenericService(id, type).setProfile(profile.textValue());
                     } else if (format != null) {
-                        service = new GenericService(id).setContext(context).setFormat(format.textValue());
+                        service = new GenericService(id, type).setFormat(format.textValue());
                     } else {
-                        service = new GenericService(id).setContext(context);
+                        service = new GenericService(id, type);
                     }
                 }
             } else {
-                final JsonNode profile = node.get(Constants.PROFILE);
-                final JsonNode format = node.get(Constants.FORMAT);
-
-                if (profile != null && format != null) {
-                    service = new GenericService(id).setProfile(profile.textValue()).setFormat(format.textValue());
-                } else if (profile != null) {
-                    service = new GenericService(id).setProfile(profile.textValue());
-                } else if (format != null) {
-                    service = new GenericService(id).setFormat(format.textValue());
-                } else {
-                    service = new GenericService(id);
-                }
+                throw new JsonParseException(aParser, LOGGER.getMessage(MessageCodes.JPA_051, id),
+                    aParser.getCurrentLocation());
             }
         } else {
             throw new JsonParseException(aParser, LOGGER.getMessage(MessageCodes.JPA_016, node.getClass().getName()),
-                    aParser.getCurrentLocation());
+                aParser.getCurrentLocation());
         }
 
         return service;

--- a/src/main/resources/iiif_presentation_messages.xml
+++ b/src/main/resources/iiif_presentation_messages.xml
@@ -11,7 +11,6 @@
   <entry key="JPA-005">Profile cannot be null</entry>
   <entry key="JPA-006">Image resource cannot be null</entry>
   <entry key="JPA-007">Context URI cannot be null</entry>
-  <entry key="JPA-008">Canvas cannot be null</entry>
   <entry key="JPA-009">SeeAlso ID cannot be null</entry>
   <entry key="JPA-010">{} isn't a valid {} behavior</entry>
   <entry key="JPA-011">Width ({}) and height ({}) must not be negative numbers</entry>
@@ -54,7 +53,6 @@
   <entry key="JPA-048">Unable to add ServiceImage to ServiceProperty: {}</entry>
   <entry key="JPA-049">Unable to add AnnotationPage to Canvas: [{}]</entry>
   <entry key="JPA-050">Unable to add annotation(s) to AnnotationPage: [{}]</entry>
-  <entry key="JPA-051">Unable to add Canvas to Manifest: {}</entry>
   <entry key="JPA-052">Unexpected and currently unsupported content resource type</entry>
   <entry key="JPA-053">Type set on service image must be: {}</entry>
   <entry key="JPA-054">Supplied behavior ('{}') conflicts with an existing behavior: {}</entry>

--- a/src/main/resources/iiif_presentation_messages.xml
+++ b/src/main/resources/iiif_presentation_messages.xml
@@ -53,6 +53,7 @@
   <entry key="JPA-048">Unable to add ServiceImage to ServiceProperty: {}</entry>
   <entry key="JPA-049">Unable to add AnnotationPage to Canvas: [{}]</entry>
   <entry key="JPA-050">Unable to add annotation(s) to AnnotationPage: [{}]</entry>
+  <entry key="JPA-051">Service doesn't contain the expected type: {}</entry>
   <entry key="JPA-052">Unexpected and currently unsupported content resource type</entry>
   <entry key="JPA-053">Type set on service image must be: {}</entry>
   <entry key="JPA-054">Supplied behavior ('{}') conflicts with an existing behavior: {}</entry>

--- a/src/main/tools/checkstyle/checkstyle-suppressions.xml
+++ b/src/main/tools/checkstyle/checkstyle-suppressions.xml
@@ -5,4 +5,5 @@
 
 <suppressions>
   <suppress files="src[\\/]main[\\/]generated[\\/]" checks="."/>
+  <suppress files="target[\\/]" checks="."/>
 </suppressions>

--- a/src/main/tools/checkstyle/checkstyle.xml
+++ b/src/main/tools/checkstyle/checkstyle.xml
@@ -87,9 +87,6 @@
       <property name="onCommentFormat" value="END GENERATED CODE" />
     </module>
   </module>
-  <module name="SuppressionFilter">
-    <property name="file" value="src/main/tools/checkstyle/checkstyle-suppressions.xml" />
-  </module>
   <module name="FileTabCharacter">
     <property name="id" value="fileTabCharacterChecker"/>
     <property name="eachLine" value="true" />

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/ManifestTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/ManifestTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -251,6 +252,44 @@ public class ManifestTest extends AbstractTest {
     }
 
     /**
+     * Tests setting and getting canvases.
+     */
+    @Test
+    public void testSetGetCanvases() {
+        final String cID1 = UUID.randomUUID().toString();
+        final String cID2 = UUID.randomUUID().toString();
+        final Canvas canvas1 = new Canvas(cID1);
+        final Canvas canvas2 = new Canvas(cID2);
+        final List<Canvas> canvases;
+
+        myManifest.setCanvases(canvas1, canvas2);
+        canvases = myManifest.getCanvases();
+
+        assertEquals(2, canvases.size());
+        assertEquals(cID1, canvases.get(0).getID().toString());
+        assertEquals(cID2, canvases.get(1).getID().toString());
+    }
+
+    /**
+     * Tests setting and getting canvases lists.
+     */
+    @Test
+    public void testSetGetCanvasesList() {
+        final String cID1 = UUID.randomUUID().toString();
+        final String cID2 = UUID.randomUUID().toString();
+        final Canvas canvas1 = new Canvas(cID1);
+        final Canvas canvas2 = new Canvas(cID2);
+        final List<Canvas> canvases;
+
+        myManifest.setCanvases(Arrays.asList(canvas1, canvas2));
+        canvases = myManifest.getCanvases();
+
+        assertEquals(2, canvases.size());
+        assertEquals(cID1, canvases.get(0).getID().toString());
+        assertEquals(cID2, canvases.get(1).getID().toString());
+    }
+
+    /**
      * Tests setting and getting ranges.
      */
     @Test
@@ -262,6 +301,25 @@ public class ManifestTest extends AbstractTest {
         final List<Range> ranges;
 
         myManifest.setRanges(range1, range2);
+        ranges = myManifest.getRanges();
+
+        assertEquals(2, ranges.size());
+        assertEquals(rID1, ranges.get(0).getID().toString());
+        assertEquals(rID2, ranges.get(1).getID().toString());
+    }
+
+    /**
+     * Tests setting and getting range lists.
+     */
+    @Test
+    public void testSetGetRangesList() {
+        final String rID1 = UUID.randomUUID().toString();
+        final String rID2 = UUID.randomUUID().toString();
+        final Range range1 = new Range(rID1);
+        final Range range2 = new Range(rID2);
+        final List<Range> ranges;
+
+        myManifest.setRanges(Arrays.asList(range1, range2));
         ranges = myManifest.getRanges();
 
         assertEquals(2, ranges.size());

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/ManifestTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/ManifestTest.java
@@ -143,8 +143,7 @@ public class ManifestTest extends AbstractTest {
         myManifest.setRights("http://creativecommons.org/licenses/by/4.0/");
         myManifest.setBehaviors(ManifestBehavior.PAGED);
 
-        final Service service = new GenericService("https://example.org/service/example")
-            .setContext("https://example.org/example-service/context.json")
+        final Service service = new GenericService("https://example.org/service/example", "example")
             .setProfile("https://example.org/docs/example-service.html");
         myManifest.setServices(service);
 

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/ManifestTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/ManifestTest.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -56,11 +57,9 @@ public class ManifestTest extends AbstractTest {
 
     private static final String TEST_TITLE = "Georgian NF Fragment 68a";
 
-    private static final List<String[]> METADATA_PAIRS = Stream
-            .of(new String[] { "Title", TEST_TITLE }, new String[] { "Extent", "1 f" },
-                    new String[] { "Overtext Language", "Georgian" },
-                    new String[] { "Undertext Language(s)", "Christian Palestinian Aramaic" })
-            .collect(Collectors.toList());
+    private static final List<String[]> METADATA_PAIRS = Stream.of(new String[] { "Title", TEST_TITLE },
+        new String[] { "Extent", "1 f" }, new String[] { "Overtext Language", "Georgian" },
+        new String[] { "Undertext Language(s)", "Christian Palestinian Aramaic" }).collect(Collectors.toList());
 
     private static final int HEIGHT = 8176;
 
@@ -91,7 +90,7 @@ public class ManifestTest extends AbstractTest {
         }
 
         final ImageService manifestThumbService =
-                new ImageService3(Profile.LEVEL_TWO, SERVER + ENCODED_MANIFEST_THUMBNAIL_ARK);
+            new ImageService3(Profile.LEVEL_TWO, SERVER + ENCODED_MANIFEST_THUMBNAIL_ARK);
 
         myManifest = new Manifest(MANIFEST_URI, TEST_TITLE);
         myManifest.setMetadata(metadata);
@@ -102,14 +101,14 @@ public class ManifestTest extends AbstractTest {
         final Thumbnail thumb1 = new ImageContent(SERVER + "ark:%2F21198%2Fz10v8vhm" + THUMBNAIL_PATH);
         final Canvas canvas1 = new Canvas(id1, label1).setWidthHeight(WIDTH, HEIGHT).setThumbnails(thumb1);
         final PaintingAnnotation content1 =
-                new PaintingAnnotation(SERVER + MANIFEST_ID + "/imageanno/imageanno-1", canvas1);
+            new PaintingAnnotation(SERVER + MANIFEST_ID + "/imageanno/imageanno-1", canvas1);
         final AnnotationPage<PaintingAnnotation> page1 =
-                new AnnotationPage<>(SERVER + MANIFEST_ID + "/pageanno/pageanno-1");
+            new AnnotationPage<>(SERVER + MANIFEST_ID + "/pageanno/pageanno-1");
         final AnnotationPage<PaintingAnnotation> page2 =
-                new AnnotationPage<>(SERVER + MANIFEST_ID + "/pageanno/pageanno-2");
+            new AnnotationPage<>(SERVER + MANIFEST_ID + "/pageanno/pageanno-2");
 
         canvas1.addPaintingPages(page1.addAnnotations(content1));
-        myManifest.addCanvas(canvas1);
+        myManifest.addCanvases(canvas1);
 
         for (final String[] values : firstCanvas) {
             final String id = SERVER + values[1] + THUMBNAIL_PATH;
@@ -124,10 +123,10 @@ public class ManifestTest extends AbstractTest {
         final Thumbnail thumb2 = new ImageContent(SERVER + "ark:%2F21198%2Fz1gq7dfx" + THUMBNAIL_PATH);
         final Canvas canvas2 = new Canvas(id2, label2).setWidthHeight(WIDTH, HEIGHT).setThumbnails(thumb2);
         final PaintingAnnotation content2 =
-                new PaintingAnnotation(SERVER + MANIFEST_ID + "/imageanno/imageanno-2", canvas2);
+            new PaintingAnnotation(SERVER + MANIFEST_ID + "/imageanno/imageanno-2", canvas2);
 
         canvas2.addPaintingPages(page2.addAnnotations(content2));
-        myManifest.addCanvas(canvas2);
+        myManifest.addCanvases(canvas2);
 
         for (final String[] values : secondCanvas) {
             final String id = SERVER + values[1] + THUMBNAIL_PATH;
@@ -138,14 +137,14 @@ public class ManifestTest extends AbstractTest {
         }
 
         final RequiredStatement reqStmt =
-                new RequiredStatement("Attribution", "Provided courtesy of Example Institution");
+            new RequiredStatement("Attribution", "Provided courtesy of Example Institution");
         myManifest.setRequiredStatement(reqStmt);
         myManifest.setRights("http://creativecommons.org/licenses/by/4.0/");
         myManifest.setBehaviors(ManifestBehavior.PAGED);
 
         final Service service = new GenericService("https://example.org/service/example")
-                .setContext("https://example.org/example-service/context.json")
-                .setProfile("https://example.org/docs/example-service.html");
+            .setContext("https://example.org/example-service/context.json")
+            .setProfile("https://example.org/docs/example-service.html");
         myManifest.setServices(service);
 
         myVertx = Vertx.factory.vertx();
@@ -252,6 +251,33 @@ public class ManifestTest extends AbstractTest {
     }
 
     /**
+     * Tests setting and getting ranges.
+     */
+    @Test
+    public void testSetGetRanges() {
+        final String rID1 = UUID.randomUUID().toString();
+        final String rID2 = UUID.randomUUID().toString();
+        final Range range1 = new Range(rID1);
+        final Range range2 = new Range(rID2);
+        final List<Range> ranges;
+
+        myManifest.setRanges(range1, range2);
+        ranges = myManifest.getRanges();
+
+        assertEquals(2, ranges.size());
+        assertEquals(rID1, ranges.get(0).getID().toString());
+        assertEquals(rID2, ranges.get(1).getID().toString());
+    }
+
+    /**
+     * Tests ranges aren't set by default in manifest.
+     */
+    @Test
+    public void testSetGetRangesCount() {
+        assertEquals(0, myManifest.getRanges().size());
+    }
+
+    /**
      * Tests manifest's toJSON().
      */
     @Test
@@ -301,8 +327,8 @@ public class ManifestTest extends AbstractTest {
      */
     @Test
     public final void testSetBehaviors() {
-        assertEquals(2, myManifest.setBehaviors(ManifestBehavior.INDIVIDUALS, ManifestBehavior.AUTO_ADVANCE)
-                .getBehaviors().size());
+        assertEquals(2,
+            myManifest.setBehaviors(ManifestBehavior.INDIVIDUALS, ManifestBehavior.AUTO_ADVANCE).getBehaviors().size());
     }
 
     /**

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/RangeTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/RangeTest.java
@@ -293,6 +293,18 @@ public class RangeTest extends AbstractTest {
         getRange().addBehaviors(RangeBehavior.AUTO_ADVANCE, ManifestBehavior.INDIVIDUALS);
     }
 
+    /**
+     * Tests round-tripping test fixture 0024.
+     *
+     * @throws IOException
+     */
+    @Test
+    public final void testFixture0024() throws IOException {
+        final String json =
+            StringUtils.read(new File("src/test/resources/fixtures/0024-book-4-toc.json"), StandardCharsets.UTF_8);
+        assertEquals(new JsonObject(json), Manifest.fromString(json).toJSON());
+    }
+
     private Range getRange() {
         return new Range(URI.create("MY_RANGE_ID"), new Label("My range label"));
     }

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/id/DefaultMinterTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/id/DefaultMinterTest.java
@@ -55,7 +55,7 @@ public class DefaultMinterTest {
     public final void testManifestConstructor() {
         final String id = myManifestID + "/canvas-kfb9";
         final Manifest manifest = new Manifest(myManifestID, new Label("Label"));
-        final Minter minter = MinterFactory.getMinter(manifest.addCanvas(new Canvas(id)));
+        final Minter minter = MinterFactory.getMinter(manifest.addCanvases(new Canvas(id)));
 
         int counter = 0;
 

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/services/GeoJSONServiceTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/services/GeoJSONServiceTest.java
@@ -1,7 +1,7 @@
 
 package info.freelibrary.iiif.presentation.v3.services;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 
@@ -20,7 +20,6 @@ public class GeoJSONServiceTest {
     @Test
     public void test() {
         assertEquals(ID, new GeoJSONService(ID).getID());
-        assertEquals(GeoJSONService.CONTEXT, new GeoJSONService(ID).getContext());
     }
 
 }

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/services/ImageService2Test.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/services/ImageService2Test.java
@@ -1,7 +1,7 @@
 
 package info.freelibrary.iiif.presentation.v3.services;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 
@@ -11,8 +11,6 @@ import org.junit.Test;
  * A ImageService2 test.
  */
 public class ImageService2Test {
-
-    private static final URI CONTEXT = URI.create("http://iiif.io/api/image/2/context.json");
 
     private static final URI ID = URI.create("asdf");
 
@@ -31,24 +29,13 @@ public class ImageService2Test {
     }
 
     /**
-     * Tests getting the image service's context.
-     */
-    @Test
-    public void testGetContext() {
-        assertEquals(CONTEXT, new ImageService2(ImageService2.Profile.LEVEL_ZERO, ID).getContext());
-    }
-
-    /**
      * Tests getting the image service's profile.
      */
     @Test
     public void testGetProfile() {
-        assertEquals(LEVEL_0, new ImageService2(ImageService2.Profile.LEVEL_ZERO, ID)
-                .getProfile());
-        assertEquals(LEVEL_1, new ImageService2(ImageService2.Profile.LEVEL_ONE, ID)
-                .getProfile());
-        assertEquals(LEVEL_2, new ImageService2(ImageService2.Profile.LEVEL_TWO, ID)
-                .getProfile());
+        assertEquals(LEVEL_0, new ImageService2(ImageService2.Profile.LEVEL_ZERO, ID).getProfile());
+        assertEquals(LEVEL_1, new ImageService2(ImageService2.Profile.LEVEL_ONE, ID).getProfile());
+        assertEquals(LEVEL_2, new ImageService2(ImageService2.Profile.LEVEL_TWO, ID).getProfile());
     }
 
     /**

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/services/ImageService3Test.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/services/ImageService3Test.java
@@ -1,7 +1,7 @@
 
 package info.freelibrary.iiif.presentation.v3.services;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 
@@ -16,11 +16,11 @@ public class ImageService3Test {
 
     private static final URI ID = URI.create("asdf");
 
-    private static final String LEVEL_0 = "http://iiif.io/api/image/3/level0.json";
+    private static final String LEVEL_0 = "level0";
 
-    private static final String LEVEL_1 = "http://iiif.io/api/image/3/level1.json";
+    private static final String LEVEL_1 = "level1";
 
-    private static final String LEVEL_2 = "http://iiif.io/api/image/3/level2.json";
+    private static final String LEVEL_2 = "level2";
 
     /**
      * Tests getting the image service's ID.

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/services/ImageService3Test.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/services/ImageService3Test.java
@@ -12,8 +12,6 @@ import org.junit.Test;
  */
 public class ImageService3Test {
 
-    private static final URI CONTEXT = URI.create("http://iiif.io/api/image/3/context.json");
-
     private static final URI ID = URI.create("asdf");
 
     private static final String LEVEL_0 = "level0";
@@ -28,14 +26,6 @@ public class ImageService3Test {
     @Test
     public void testGetID() {
         assertEquals(ID, new ImageService3(ID).getID());
-    }
-
-    /**
-     * Tests getting the image service's context.
-     */
-    @Test
-    public void testGetContext() {
-        assertEquals(CONTEXT, new ImageService3(ImageService3.Profile.LEVEL_ZERO, ID).getContext());
     }
 
     /**

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/services/PhysicalDimsServiceTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/services/PhysicalDimsServiceTest.java
@@ -1,7 +1,7 @@
 
 package info.freelibrary.iiif.presentation.v3.services;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 
@@ -26,7 +26,6 @@ public class PhysicalDimsServiceTest {
         PhysicalDimsService service;
 
         assertEquals(ID, new PhysicalDimsService(ID).getID());
-        assertEquals(PhysicalDimsService.CONTEXT, new PhysicalDimsService(ID).getContext());
         assertEquals(PhysicalDimsService.PROFILE, new PhysicalDimsService(ID).getProfile());
         assertEquals(SCALE, new PhysicalDimsService(ID).setPhysicalScale(SCALE).getPhysicalScale(), 0);
         assertEquals(UNITS, new PhysicalDimsService(ID).setPhysicalUnits(UNITS).getPhysicalUnits());

--- a/src/test/resources/fixtures/0024-book-4-toc.json
+++ b/src/test/resources/fixtures/0024-book-4-toc.json
@@ -1,0 +1,327 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Ethiopic Ms 10"
+    ]
+  },
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p1",
+      "type": "Canvas",
+      "label": {
+        "en": [
+          "f. 1r"
+        ]
+      },
+      "height": 2504,
+      "width": 1768,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-1-21198-zz001d8m41_774608_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2504,
+                "width": 1768,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-1-21198-zz001d8m41_774608_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p2",
+      "type": "Canvas",
+      "label": {
+        "en": [
+          "f. 1v"
+        ]
+      },
+      "height": 2512,
+      "width": 1792,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p2/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0002-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-2-21198-zz001d8m5j_774612_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2512,
+                "width": 1792,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-2-21198-zz001d8m5j_774612_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p3",
+      "type": "Canvas",
+      "label": {
+        "en": [
+          "f. 2r"
+        ]
+      },
+      "height": 2456,
+      "width": 1792,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p3/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0003-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-3-21198-zz001d8tm5_775004_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2456,
+                "width": 1792,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-3-21198-zz001d8tm5_775004_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p4",
+      "type": "Canvas",
+      "label": {
+        "en": [
+          "f. 2v"
+        ]
+      },
+      "height": 2440,
+      "width": 1760,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p4/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0004-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-4-21198-zz001d8tnp_775007_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2440,
+                "width": 1760,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-4-21198-zz001d8tnp_775007_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p5",
+      "type": "Canvas",
+      "label": {
+        "en": [
+          "f. 3r"
+        ]
+      },
+      "height": 2416,
+      "width": 1776,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p5/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0005-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-5-21198-zz001d8v6f_775077_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2416,
+                "width": 1776,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-5-21198-zz001d8v6f_775077_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p6",
+      "type": "Canvas",
+      "label": {
+        "en": [
+          "f. 3v"
+        ]
+      },
+      "height": 2416,
+      "width": 1776,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p6/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0006-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-6-21198-zz001d8v7z_775085_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2416,
+                "width": 1776,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-6-21198-zz001d8v7z_775085_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p6"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r0",
+      "type": "Range",
+      "label": {
+        "en": [
+          "Table of Contents"
+        ]
+      },
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r1",
+          "type": "Range",
+          "label": {
+            "gez": [
+              "Tabiba Tabiban [ጠቢበ ጠቢባን]"
+            ]
+          },
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p1",
+              "type": "Canvas"
+            },
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p2",
+              "type": "Canvas"
+            }
+          ]
+        },
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r2",
+          "type": "Range",
+          "label": {
+            "gez": [
+              "Arede'et [አርድዕት]"
+            ]
+          },
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r2/1",
+              "type": "Range",
+              "label": {
+                "en": [
+                  "Monday"
+                ]
+              },
+              "items": [
+                {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p3",
+                  "type": "Canvas"
+                },
+                {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p4",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r2/2",
+              "type": "Range",
+              "label": {
+                "en": [
+                  "Tuesday"
+                ]
+              },
+              "items": [
+                {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p5",
+                  "type": "Canvas"
+                },
+                {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p6",
+                  "type": "Canvas"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/json/canvas-full.json
+++ b/src/test/resources/json/canvas-full.json
@@ -13,7 +13,6 @@
       "format": "image/jpeg",
       "service": [
         {
-          "@context": "http://iiif.io/api/image/3/context.json",
           "type": "ImageService3",
           "id": "https://example.org/iiif/book1/page1",
           "profile": "level0"
@@ -38,7 +37,6 @@
             "format": "image/jpeg",
             "service": [
               {
-                "@context": "http://iiif.io/api/image/3/context.json",
                 "type": "ImageService3",
                 "id": "https://example.org/iiif/book1/page1",
                 "profile": "level0"

--- a/src/test/resources/json/canvas-full.json
+++ b/src/test/resources/json/canvas-full.json
@@ -16,7 +16,7 @@
           "@context": "http://iiif.io/api/image/3/context.json",
           "type": "ImageService3",
           "id": "https://example.org/iiif/book1/page1",
-          "profile": "http://iiif.io/api/image/3/level0.json"
+          "profile": "level0"
         }
       ]
     }
@@ -41,7 +41,7 @@
                 "@context": "http://iiif.io/api/image/3/context.json",
                 "type": "ImageService3",
                 "id": "https://example.org/iiif/book1/page1",
-                "profile": "http://iiif.io/api/image/3/level0.json"
+                "profile": "level0"
               }
             ]
           },

--- a/src/test/resources/json/canvas-image-choice.json
+++ b/src/test/resources/json/canvas-image-choice.json
@@ -27,7 +27,7 @@
                     "@context": "http://iiif.io/api/image/3/context.json",
                     "type": "ImageService3",
                     "id": "https://example.org/iiif/book1/page1",
-                    "profile": "http://iiif.io/api/image/3/level0.json"
+                    "profile": "level0"
                   }
                 ]
               },
@@ -42,7 +42,7 @@
                     "@context": "http://iiif.io/api/image/3/context.json",
                     "type": "ImageService3",
                     "id": "https://example.org/iiif/book1/page1",
-                    "profile": "http://iiif.io/api/image/3/level0.json"
+                    "profile": "level0"
                   }
                 ]
               }

--- a/src/test/resources/json/canvas-image-choice.json
+++ b/src/test/resources/json/canvas-image-choice.json
@@ -24,7 +24,6 @@
                 "format": "image/jpeg",
                 "service": [
                   {
-                    "@context": "http://iiif.io/api/image/3/context.json",
                     "type": "ImageService3",
                     "id": "https://example.org/iiif/book1/page1",
                     "profile": "level0"
@@ -39,7 +38,6 @@
                 "format": "image/jpeg",
                 "service": [
                   {
-                    "@context": "http://iiif.io/api/image/3/context.json",
                     "type": "ImageService3",
                     "id": "https://example.org/iiif/book1/page1",
                     "profile": "level0"

--- a/src/test/resources/json/canvas-image-multi.json
+++ b/src/test/resources/json/canvas-image-multi.json
@@ -24,7 +24,7 @@
                 "@context": "http://iiif.io/api/image/3/context.json",
                 "type": "ImageService3",
                 "id": "https://example.org/iiif/book1/page1",
-                "profile": "http://iiif.io/api/image/3/level0.json"
+                "profile": "level0"
               }
             ]
           },
@@ -53,7 +53,7 @@
                 "@context": "http://iiif.io/api/image/3/context.json",
                 "type": "ImageService3",
                 "id": "https://example.org/iiif/book1/page1",
-                "profile": "http://iiif.io/api/image/3/level0.json"
+                "profile": "level0"
               }
             ]
           },

--- a/src/test/resources/json/canvas-image-multi.json
+++ b/src/test/resources/json/canvas-image-multi.json
@@ -21,7 +21,6 @@
             "format": "image/jpeg",
             "service": [
               {
-                "@context": "http://iiif.io/api/image/3/context.json",
                 "type": "ImageService3",
                 "id": "https://example.org/iiif/book1/page1",
                 "profile": "level0"
@@ -50,7 +49,6 @@
             "format": "image/jpeg",
             "service": [
               {
-                "@context": "http://iiif.io/api/image/3/context.json",
                 "type": "ImageService3",
                 "id": "https://example.org/iiif/book1/page1",
                 "profile": "level0"

--- a/src/test/resources/json/canvas-image.json
+++ b/src/test/resources/json/canvas-image.json
@@ -21,7 +21,6 @@
             "format": "image/jpeg",
             "service": [
               {
-                "@context": "http://iiif.io/api/image/3/context.json",
                 "type": "ImageService3",
                 "id": "https://example.org/iiif/book1/page1",
                 "profile": "level0"

--- a/src/test/resources/json/canvas-image.json
+++ b/src/test/resources/json/canvas-image.json
@@ -24,7 +24,7 @@
                 "@context": "http://iiif.io/api/image/3/context.json",
                 "type": "ImageService3",
                 "id": "https://example.org/iiif/book1/page1",
-                "profile": "http://iiif.io/api/image/3/level0.json"
+                "profile": "level0"
               }
             ]
           },

--- a/src/test/resources/json/imageinfoservice.json
+++ b/src/test/resources/json/imageinfoservice.json
@@ -1,6 +1,5 @@
 {
-  "@context" : "http://iiif.io/api/image/3/context.json",
   "type": "ImageService3",
   "id" : "http://example.org/asdf",
-  "profile" : "http://iiif.io/api/image/3/level0.json"
+  "profile" : "level0"
 }

--- a/src/test/resources/json/logo-addimage-string-imageinfoservice.json
+++ b/src/test/resources/json/logo-addimage-string-imageinfoservice.json
@@ -13,7 +13,6 @@
             "format": "image/jpeg",
             "service": [
                 {
-                    "@context": "http://iiif.io/api/image/3/context.json",
                     "type": "ImageService3",
                     "id": "http://example.org/asdf",
                     "profile": "http://iiif.io/api/image/3/level0.json"

--- a/src/test/resources/json/logo-string-imageinfoservice.json
+++ b/src/test/resources/json/logo-string-imageinfoservice.json
@@ -6,7 +6,6 @@
             "format": "image/jpeg",
             "service": [
                 {
-                    "@context": "http://iiif.io/api/image/3/context.json",
                     "type": "ImageService3",
                     "id": "http://example.org/asdf",
                     "profile": "http://iiif.io/api/image/3/level0.json"

--- a/src/test/resources/json/z1960050.json
+++ b/src/test/resources/json/z1960050.json
@@ -28,7 +28,6 @@
       "format": "image/jpeg",
       "service": [
         {
-          "@context": "http://iiif.io/api/image/3/context.json",
           "type": "ImageService3",
           "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1d79t3q",
           "profile": "level2"
@@ -129,7 +128,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1d79t3q",
                         "profile": "level2"
@@ -149,7 +147,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz18g92cc",
                         "profile": "level2"
@@ -169,7 +166,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1w672gs",
                         "profile": "level2"
@@ -189,7 +185,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1rj5167",
                         "profile": "level2"
@@ -209,7 +204,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1ms48gh",
                         "profile": "level2"
@@ -229,7 +223,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1h13hqn",
                         "profile": "level2"
@@ -249,7 +242,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1c82s0b",
                         "profile": "level2"
@@ -269,7 +261,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz13r18m5",
                         "profile": "level2"
@@ -289,7 +280,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1ks7787",
                         "profile": "level2"
@@ -309,7 +299,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1b85qvj",
                         "profile": "level2"
@@ -329,7 +318,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz16h5052",
                         "profile": "level2"
@@ -349,7 +337,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1pk0xvb",
                         "profile": "level2"
@@ -369,7 +356,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1d22dbh",
                         "profile": "level2"
@@ -389,7 +375,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz14m9m97",
                         "profile": "level2"
@@ -446,7 +431,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1w38c11",
                         "profile": "level2"
@@ -466,7 +450,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1rb7m99",
                         "profile": "level2"
@@ -486,7 +469,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1c542k0",
                         "profile": "level2"
@@ -506,7 +488,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz17d39wq",
                         "profile": "level2"
@@ -526,7 +507,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz13n2k3h",
                         "profile": "level2"
@@ -546,7 +526,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1zw22m6",
                         "profile": "level2"
@@ -566,7 +545,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1v419ws",
                         "profile": "level2"
@@ -586,7 +564,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1kk9th3",
                         "profile": "level2"
@@ -606,7 +583,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz12n5hzq",
                         "profile": "level2"
@@ -626,7 +602,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1t448sv",
                         "profile": "level2"
@@ -646,7 +621,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1pc3j30",
                         "profile": "level2"
@@ -666,7 +640,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz15d97j2",
                         "profile": "level2"
@@ -686,7 +659,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1vx0z84",
                         "profile": "level2"
@@ -706,7 +678,6 @@
                     "format": "image/jpeg",
                     "service": [
                       {
-                        "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1mg8563",
                         "profile": "level2"
@@ -724,8 +695,8 @@
   ],
   "service": [
     {
-      "@context": "https://example.org/example-service/context.json",
       "id": "https://example.org/service/example",
+      "type": "example",
       "profile": "https://example.org/docs/example-service.html"
     }
   ]

--- a/src/test/resources/json/z1960050.json
+++ b/src/test/resources/json/z1960050.json
@@ -31,7 +31,7 @@
           "@context": "http://iiif.io/api/image/3/context.json",
           "type": "ImageService3",
           "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1d79t3q",
-          "profile": "http://iiif.io/api/image/3/level2.json"
+          "profile": "level2"
         }
       ]
     }
@@ -132,7 +132,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1d79t3q",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -152,7 +152,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz18g92cc",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -172,7 +172,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1w672gs",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -192,7 +192,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1rj5167",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -212,7 +212,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1ms48gh",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -232,7 +232,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1h13hqn",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -252,7 +252,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1c82s0b",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -272,7 +272,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz13r18m5",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -292,7 +292,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1ks7787",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -312,7 +312,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1b85qvj",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -332,7 +332,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz16h5052",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -352,7 +352,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1pk0xvb",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -372,7 +372,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1d22dbh",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -392,7 +392,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz14m9m97",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   }
@@ -449,7 +449,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1w38c11",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -469,7 +469,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1rb7m99",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -489,7 +489,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1c542k0",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -509,7 +509,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz17d39wq",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -529,7 +529,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz13n2k3h",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -549,7 +549,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1zw22m6",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -569,7 +569,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1v419ws",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -589,7 +589,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1kk9th3",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -609,7 +609,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz12n5hzq",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -629,7 +629,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1t448sv",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -649,7 +649,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1pc3j30",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -669,7 +669,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz15d97j2",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -689,7 +689,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1vx0z84",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   },
@@ -709,7 +709,7 @@
                         "@context": "http://iiif.io/api/image/3/context.json",
                         "type": "ImageService3",
                         "id": "https://sinai-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1mg8563",
-                        "profile": "http://iiif.io/api/image/3/level2.json"
+                        "profile": "level2"
                       }
                     ]
                   }


### PR DESCRIPTION
Went in to fix the range bug and, when I used one of the new v3 test fixtures to test, I found some service-related bugs too. Their fixes are included too.

* Ranges should be in an array on manifests (2)
* Services should not contain context (1)
* Services must contain type (1)
* Service v3 profile value is not a URI (1)
* Add list setters for manifest members
* Fix pluralization of `addCanvases()` since it takes a varargs

1) https://iiif.io/api/presentation/3.0/#service
2) https://iiif.io/api/presentation/3.0/#structures

The newer version of Eclipse also has some formatting differences that I didn't catch before editing again so the PR is full of those sorts of changes too. :-(

Fixes #96 