### PR TITLE
Check for Manifest/Collection in fromJSON()

### DIFF
--- a/src/main/java/info/freelibrary/iiif/presentation/v3/Collection.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/Collection.java
@@ -46,6 +46,11 @@ import io.vertx.core.json.JsonObject;
 public class Collection extends NavigableResource<Collection> implements Resource<Collection> {
 
     /**
+     * The logger used by the collection.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(Collection.class, MessageCodes.BUNDLE);
+
+    /**
      * The collection's accompanying canvas.
      */
     private Optional<AccompanyingCanvas> myAccompanyingCanvas;
@@ -466,6 +471,12 @@ public class Collection extends NavigableResource<Collection> implements Resourc
      */
     @JsonIgnore
     public static Collection fromJSON(final JsonObject aJsonObject) {
+        final String type = aJsonObject.getString(Constants.TYPE);
+
+        if (!ResourceTypes.COLLECTION.equals(type)) {
+            throw new IllegalArgumentException(LOGGER.getMessage(MessageCodes.JPA_119, ResourceTypes.COLLECTION, type));
+        }
+
         return Json.decodeValue(aJsonObject.toString(), Collection.class);
     }
 

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/Collection.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/Collection.java
@@ -23,6 +23,7 @@ import info.freelibrary.iiif.presentation.v3.properties.Behavior;
 import info.freelibrary.iiif.presentation.v3.properties.Homepage;
 import info.freelibrary.iiif.presentation.v3.properties.Label;
 import info.freelibrary.iiif.presentation.v3.properties.Metadata;
+import info.freelibrary.iiif.presentation.v3.properties.NavDate;
 import info.freelibrary.iiif.presentation.v3.properties.PartOf;
 import info.freelibrary.iiif.presentation.v3.properties.Provider;
 import info.freelibrary.iiif.presentation.v3.properties.Rendering;
@@ -495,7 +496,7 @@ public class Collection extends NavigableResource<Collection> implements Resourc
      * A wrapper for things embedded in or referenced from a collection (e&#46;g&#46; manifests and other collections).
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @JsonPropertyOrder({ Constants.ID, Constants.TYPE, Constants.LABEL, Constants.THUMBNAIL })
+    @JsonPropertyOrder({ Constants.ID, Constants.TYPE, Constants.LABEL, Constants.THUMBNAIL, Constants.NAV_DATE })
     public static class Item {
 
         /**
@@ -561,6 +562,11 @@ public class Collection extends NavigableResource<Collection> implements Resourc
          * The collection item's label.
          */
         private Label myLabel;
+
+        /**
+         * The collection item's navDate.
+         */
+        private NavDate myNavDate;
 
         /**
          * The collection item's thumbnails.
@@ -765,6 +771,28 @@ public class Collection extends NavigableResource<Collection> implements Resourc
         @JsonIgnore
         public Item setLabel(final String aLabel) {
             myLabel = new Label(aLabel);
+            return this;
+        }
+
+        /**
+         * Gets a navigation date.
+         *
+         * @return The navigation date
+         */
+        @JsonGetter(Constants.NAV_DATE)
+        public NavDate getNavDate() {
+            return myNavDate;
+        }
+
+        /**
+         * Sets a navigation date.
+         *
+         * @param aNavDate The navigation date
+         * @return The navigable resource
+         */
+        @JsonSetter(Constants.NAV_DATE)
+        public Item setNavDate(final NavDate aNavDate) {
+            myNavDate = aNavDate;
             return this;
         }
 

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/Manifest.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/Manifest.java
@@ -754,6 +754,12 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      */
     @JsonIgnore
     public static Manifest fromJSON(final JsonObject aJsonObject) {
+        final String type = aJsonObject.getString(Constants.TYPE);
+
+        if (!ResourceTypes.MANIFEST.equals(type)) {
+            throw new IllegalArgumentException(LOGGER.getMessage(MessageCodes.JPA_119, ResourceTypes.MANIFEST, type));
+        }
+
         return Json.decodeValue(aJsonObject.toString(), Manifest.class);
     }
 

--- a/src/main/resources/iiif_presentation_messages.xml
+++ b/src/main/resources/iiif_presentation_messages.xml
@@ -89,5 +89,6 @@
   <entry key="JPA-116">Unexpected Annotation body type: {}</entry>
   <entry key="JPA-117">Won't try to build a PointSelector without a temporal or X and Y point</entry>
   <entry key="JPA-118">The supplied value isn't a valid collection item type: {}</entry>
+  <entry key="JPA-119">The supplied JSON object does not look like it's a {}; its type is: {}</entry>
 
 </properties>

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/CollectionTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/CollectionTest.java
@@ -147,6 +147,17 @@ public class CollectionTest {
     }
 
     /**
+     * Test collection doc creation fromJSON() with a Manifest.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromJsonManifest() {
+        final String collectionPath = new File(TestUtils.TEST_DIR, "z1960050.json").getAbsolutePath();
+        final JsonObject json = new JsonObject(myVertx.fileSystem().readFileBlocking(collectionPath));
+
+        Collection.fromJSON(json);
+    }
+
+    /**
      * Tests reading a collection document from a JSON string.
      */
     @Test

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/ManifestTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/ManifestTest.java
@@ -350,6 +350,17 @@ public class ManifestTest extends AbstractTest {
     }
 
     /**
+     * Test manifest creation fromJSON() with a Collection.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromJsonCollection() {
+        final String collectionPath = new File(TestUtils.TEST_DIR, "collection1.json").getAbsolutePath();
+        final JsonObject json = new JsonObject(myVertx.fileSystem().readFileBlocking(collectionPath));
+
+        Manifest.fromJSON(json);
+    }
+
+    /**
      * Tests manifest creation fromString().
      */
     @Test

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/cookbooks/RoundTripTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/cookbooks/RoundTripTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import info.freelibrary.util.StringUtils;
 
+import info.freelibrary.iiif.presentation.v3.Collection;
 import info.freelibrary.iiif.presentation.v3.Constants;
 import info.freelibrary.iiif.presentation.v3.Manifest;
 
@@ -383,14 +384,15 @@ public class RoundTripTest {
     }
 
     /**
-     * Tests the 0068 title collection cookbook manifest (cf. https://iiif.io/api/cookbook/recipe/0068-newspaper/).
+     * Tests the 0068 title collection cookbook's collection doc (cf.
+     * https://iiif.io/api/cookbook/recipe/0068-newspaper/).
      *
      * @throws IOException If there is trouble reading the manifest file
      */
     @Test
     public final void test0068NewspaperTitleCollection() throws IOException {
         final JsonObject expected = getManifest("0068-newspaper_title-collection");
-        final JsonObject found = Manifest.fromJSON(expected).toJSON();
+        final JsonObject found = Collection.fromJSON(expected).toJSON();
 
         compare(expected, found);
     }
@@ -487,14 +489,14 @@ public class RoundTripTest {
     }
 
     /**
-     * Tests the 0230 collection cookbook manifest (cf. https://iiif.io/api/cookbook/recipe/0230-navdate/).
+     * Tests the 0230 collection cookbook's collection doc (cf. https://iiif.io/api/cookbook/recipe/0230-navdate/).
      *
      * @throws IOException If there is trouble reading the manifest file
      */
     @Test
     public final void test0230NavDateCollection() throws IOException {
         final JsonObject expected = getManifest("0230-navdate-collection");
-        final JsonObject found = Manifest.fromJSON(expected).toJSON();
+        final JsonObject found = Collection.fromJSON(expected).toJSON();
 
         compare(expected, found);
     }


### PR DESCRIPTION
Prevent more obscure errors by checking the JsonObject when using `fromJSON()` in Manifest and Collection.