### PR TITLE
Ignore local logging config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@
 src/
 target/
 
+# Ignore local logging configuration
+logback-test.xml
+
 # Ignore workflow artifacts
 .flattened-pom.xml


### PR DESCRIPTION
We can override the default test logging config by keeping a logback-test.xml file in the root directory. We don't want this checked in though, so we add it to the gitignore.