### PR TITLE
Update dependencies, parent + fix returned null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,10 +68,10 @@
   <properties>
     <revision>0.0.0-SNAPSHOT</revision>
 
-    <jackson.version>2.13.3</jackson.version>
-    <jackson.databind.version>2.13.3</jackson.databind.version>
-    <freelib.utils.version>3.0.1</freelib.utils.version>
-    <jsoup.version>1.15.1</jsoup.version>
+    <jackson.version>2.13.4</jackson.version>
+    <jackson.databind.version>2.13.4.2</jackson.databind.version>
+    <freelib.utils.version>3.2.4</freelib.utils.version>
+    <jsoup.version>1.15.3</jsoup.version>
     <combinatorics.version>3.3.0</combinatorics.version>
     <media.fragments.uri.version>2.4</media.fragments.uri.version>
 
@@ -287,6 +287,31 @@
 
   <profiles>
     <profile>
+      <id>snyk-check</id>
+      <activation>
+        <property>
+          <name>env.SNYK_TOKEN</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.snyk</groupId>
+            <artifactId>snyk-maven-plugin</artifactId>
+            <!-- Configurations have to be overridden in the executions' configuration elements -->
+            <executions>
+              <execution>
+                <id>snyk-test</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>native-build</id>
       <activation>
         <file>
@@ -334,7 +359,7 @@
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>7.2.1</version>
+    <version>7.4.2</version>
   </parent>
 
 </project>

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/Manifest.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/Manifest.java
@@ -293,8 +293,9 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
     @JsonIgnore
     public List<URI> getContexts() {
         if (myContexts.isEmpty()) {
-            return null;
+            return Collections.emptyList();
         }
+
         return Collections.unmodifiableList(myContexts);
     }
 

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/ServiceDeserializer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/ServiceDeserializer.java
@@ -94,7 +94,8 @@ class ServiceDeserializer extends StdDeserializer<Service<?>> { // NOPMD
      * @param aNode A JSON node representing a service
      * @return A service
      */
-    @SuppressWarnings({ PMD.CYCLOMATIC_COMPLEXITY, "PMD.CyclomaticComplexity" })
+    @SuppressWarnings({ PMD.CYCLOMATIC_COMPLEXITY, "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity",
+        PMD.COGNITIVE_COMPLEXITY })
     private Service<?> deserializeServiceNode(final JsonParser aParser, final JsonNode aNode)
             throws JsonProcessingException {
         final Service<?> service;

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/ids/DefaultMinter.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/ids/DefaultMinter.java
@@ -269,6 +269,7 @@ class DefaultMinter implements Minter {
      *
      * @param aManifest A supplied manifest
      */
+    @SuppressWarnings({ "PMD.CognitiveComplexity", PMD.COGNITIVE_COMPLEXITY })
     private void findPreexistingIDs(final Manifest aManifest) {
         for (final Canvas canvas : aManifest.getCanvases()) {
             if (!myExistingIDs.add(canvas.getID())) {
@@ -370,29 +371,31 @@ class DefaultMinter implements Minter {
         @Override
         @SuppressWarnings(PMD.AVOID_DEEPLY_NESTED_IF_STMTS)
         public String next() {
-            if (hasNext()) {
-                final String noid = NOIDS.get(myIndex);
+            final String noid;
 
-                // Check to see if we've retrieved all the possible NOIDs and increment if not
-                if (++myCount < MAX_NOID_COUNT) {
-                    myIndex += mySkipCount;
-
-                    // When at the end of an iteration cycle, reset the index to a new start
-                    if (myIndex >= MAX_NOID_COUNT) {
-                        myIndex = ++myIteration + myStart;
-
-                        // Loop around to get the remaining ones from the start of the array
-                        if (myIndex >= mySkipCount + myStart) { // NOPMD
-                            mySkipCount = 1;
-                            myIndex = 0;
-                        }
-                    }
-                }
-
-                return noid;
-            } else {
+            if (!hasNext()) {
                 throw new IndexOutOfBoundsException(myIndex);
             }
+
+            noid = NOIDS.get(myIndex);
+
+            // Check to see if we've retrieved all the possible NOIDs and increment if not
+            if (++myCount < MAX_NOID_COUNT) {
+                myIndex += mySkipCount;
+
+                // When at the end of an iteration cycle, reset the index to a new start
+                if (myIndex >= MAX_NOID_COUNT) {
+                    myIndex = ++myIteration + myStart;
+
+                    // Loop around to get the remaining ones from the start of the array
+                    if (myIndex >= mySkipCount + myStart) { // NOPMD
+                        mySkipCount = 1;
+                        myIndex = 0;
+                    }
+                }
+            }
+
+            return noid;
         }
 
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/properties/selectors/MediaFragmentSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/properties/selectors/MediaFragmentSelector.java
@@ -376,7 +376,7 @@ public class MediaFragmentSelector implements FragmentSelector {
      * @return True if this selector has a temporal end; else, false
      */
     public boolean hasEnd() {
-        return myMediaFragment.getTemporalFragment().getEnd() != Clocktime.INFINIT;
+        return !Clocktime.INFINIT.equals(myMediaFragment.getTemporalFragment().getEnd());
     }
 
     /**

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/OtherService2.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/OtherService2.java
@@ -160,6 +160,7 @@ public final class OtherService2 extends AbstractOtherService<OtherService2> imp
      */
     @Override
     @JsonValue
+    @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull") // This is for Jackson
     protected Map<String, Object> toJsonValue() {
         final LinkedHashMap<String, Object> map = new LinkedHashMap<>();
         final List<Service<?>> services;

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/OtherService3.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/OtherService3.java
@@ -191,6 +191,7 @@ public final class OtherService3 extends AbstractOtherService<OtherService3> imp
      */
     @Override
     @JsonValue
+    @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull") // This is for Jackson
     protected Map<String, Object> toJsonValue() {
         final LinkedHashMap<String, Object> map = new LinkedHashMap<>();
         final List<Service<?>> services;

--- a/src/main/tools/checkstyle/checkstyle-suppressions.xml
+++ b/src/main/tools/checkstyle/checkstyle-suppressions.xml
@@ -5,5 +5,7 @@
 
 <suppressions>
   <suppress files="src[\\/]main[\\/]generated[\\/]" checks="."/>
+  <suppress files="src[\\/]test[\\/]generated[\\/]" checks="."/>
   <suppress files="target[\\/]" checks="."/>
+  <suppress files=".mvn[\\/]" checks="."/>
 </suppressions>


### PR DESCRIPTION
* Updates dependencies and parent project versions for security fix
* Ignore some PMD complaints that are a result of parent project PMD rule updates
* Change `Manifest`'s `List<URI> getContexts()` to return an empty list instead of a null when there are none (I think this is non-breaking because null checks won't _need_ to be changed and list handling should just be skipped with an empty list(?))
* Add new Snyk configuration needed by parent project update

Fixes #165