### PR TITLE
Resolve Snyk warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <media.fragments.uri.version>2.4</media.fragments.uri.version>
 
     <!-- GraalVM related property values -->
-    <graalvm.version>21.1.0</graalvm.version>
+    <graalvm.version>21.3.2</graalvm.version>
     <!-- Optional: location of installed native-image -->
     <gu>${env.JAVA_HOME}/lib/installer/bin/gu</gu>
 
@@ -352,7 +352,7 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
+   </profile>
   </profiles>
 
   <!-- Pulls in standard FreeLibrary Project configuration options -->


### PR DESCRIPTION
Fix security warning about the GraalVM builder. This is not currently used, so updating the version doesn't really affect anything.