### PR TITLE
Configure NON-ABSENTs in classes instead of JSON util

### DIFF
--- a/src/main/java/info/freelibrary/iiif/presentation/v3/Canvas.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/Canvas.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -150,6 +152,7 @@ public class Canvas extends AbstractCanvas<Canvas> implements CanvasResource<Can
      * @return A placeholder canvas
      */
     @JsonGetter(JsonKeys.PLACEHOLDER_CANVAS)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<PlaceholderCanvas> getPlaceholderCanvas() {
         return myPlaceholderCanvas;
     }
@@ -172,6 +175,7 @@ public class Canvas extends AbstractCanvas<Canvas> implements CanvasResource<Can
      * @return The accompanying canvas
      */
     @JsonGetter(JsonKeys.ACCOMPANYING_CANVAS)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<AccompanyingCanvas> getAccompanyingCanvas() {
         return myAccompanyingCanvas;
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/Collection.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/Collection.java
@@ -151,6 +151,7 @@ public class Collection extends NavigableResource<Collection> implements Resourc
      * @return A placeholder canvas
      */
     @JsonGetter(JsonKeys.PLACEHOLDER_CANVAS)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<PlaceholderCanvas> getPlaceholderCanvas() {
         return myPlaceholderCanvas;
     }
@@ -173,6 +174,7 @@ public class Collection extends NavigableResource<Collection> implements Resourc
      * @return The accompanying canvas
      */
     @JsonGetter(JsonKeys.ACCOMPANYING_CANVAS)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<AccompanyingCanvas> getAccompanyingCanvas() {
         return myAccompanyingCanvas;
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/Manifest.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/Manifest.java
@@ -14,6 +14,8 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -219,6 +221,7 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      * @return A placeholder canvas
      */
     @JsonGetter(JsonKeys.PLACEHOLDER_CANVAS)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<PlaceholderCanvas> getPlaceholderCanvas() {
         return Optional.ofNullable(myPlaceholderCanvas);
     }
@@ -241,6 +244,7 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      * @return The accompanying canvas
      */
     @JsonGetter(JsonKeys.ACCOMPANYING_CANVAS)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<AccompanyingCanvas> getAccompanyingCanvas() {
         return Optional.ofNullable(myAccompanyingCanvas);
     }
@@ -483,6 +487,7 @@ public class Manifest extends NavigableResource<Manifest> implements Resource<Ma
      * @return The optional start canvas
      */
     @JsonGetter(JsonKeys.START)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Start> getStart() {
         return Optional.ofNullable(myStart);
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/Range.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/Range.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -176,6 +178,7 @@ public class Range extends NavigableResource<Range> implements Resource<Range> {
      * @return The annotation collection linked to this range
      */
     @JsonGetter(JsonKeys.SUPPLEMENTARY)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<SupplementaryAnnotations> getSupplementaryAnnotations() {
         return Optional.ofNullable(mySupplementaryAnnotations);
     }
@@ -198,6 +201,7 @@ public class Range extends NavigableResource<Range> implements Resource<Range> {
      * @return A placeholder canvas
      */
     @JsonGetter(JsonKeys.PLACEHOLDER_CANVAS)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<PlaceholderCanvas> getPlaceholderCanvas() {
         return Optional.ofNullable(myPlaceholderCanvas);
     }
@@ -220,6 +224,7 @@ public class Range extends NavigableResource<Range> implements Resource<Range> {
      * @return The accompanying canvas
      */
     @JsonGetter(JsonKeys.ACCOMPANYING_CANVAS)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<AccompanyingCanvas> getAccompanyingCanvas() {
         return Optional.ofNullable(myAccompanyingCanvas);
     }
@@ -281,6 +286,7 @@ public class Range extends NavigableResource<Range> implements Resource<Range> {
      * @return The optional start
      */
     @JsonGetter(JsonKeys.START)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Start> getStart() {
         return Optional.ofNullable(myStart);
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/ids/SkolemIriFactory.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/ids/SkolemIriFactory.java
@@ -105,9 +105,8 @@ public final class SkolemIriFactory {
     public URI getSkolemIRI() {
         if (myWellKnownBase == null) {
             return URI.create(UUID.randomUUID().toString());
-        } else {
-            return URI.create(myWellKnownBase + COMPONENT_START + UUID.randomUUID().toString());
         }
+        return URI.create(myWellKnownBase + COMPONENT_START + UUID.randomUUID().toString());
     }
 
     /**

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/properties/PartOf.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/properties/PartOf.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import info.freelibrary.util.warnings.Eclipse;
@@ -87,6 +89,7 @@ public class PartOf extends AbstractLinkProperty<PartOf> {
      *
      * @return An optional descriptive label
      */
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Label> getLabel() {
         return Optional.ofNullable(super.getNullableLabel());
     }
@@ -125,11 +128,7 @@ public class PartOf extends AbstractLinkProperty<PartOf> {
 
     @Override
     public boolean equals(final Object aObject) {
-        if (!super.equals(aObject)) {
-            return false;
-        }
-
-        if (getClass() != aObject.getClass()) {
+        if (!super.equals(aObject) || getClass() != aObject.getClass()) {
             return false;
         }
 

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/properties/SeeAlso.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/properties/SeeAlso.java
@@ -156,6 +156,7 @@ public class SeeAlso extends AbstractLinkProperty<SeeAlso> {
      * @return An optional descriptive label
      */
     @JsonGetter(JsonKeys.LABEL)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Label> getLabel() {
         return Optional.ofNullable(super.getNullableLabel());
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/properties/Start.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/properties/Start.java
@@ -169,7 +169,7 @@ public class Start {
      * @return The start source
      */
     @JsonGetter(JsonKeys.SOURCE)
-    @JsonInclude(Include.NON_NULL)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<URI> getSource() {
         return Optional.ofNullable(mySource);
     }
@@ -180,7 +180,7 @@ public class Start {
      * @return A selector
      */
     @JsonGetter(JsonKeys.SELECTOR)
-    @JsonInclude(Include.NON_NULL)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Selector> getSelector() {
         return Optional.ofNullable(mySelector);
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/properties/selectors/PointSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/properties/selectors/PointSelector.java
@@ -124,6 +124,7 @@ public class PointSelector implements Selector {
      *
      * @return The X coordinate
      */
+    @JsonInclude(Include.NON_ABSENT)
     public OptionalInt getX() {
         return myX;
     }
@@ -144,6 +145,7 @@ public class PointSelector implements Selector {
      *
      * @return The Y coordinate
      */
+    @JsonInclude(Include.NON_ABSENT)
     public OptionalInt getY() {
         return myY;
     }
@@ -178,6 +180,7 @@ public class PointSelector implements Selector {
      * @return The number of seconds since the start of the resource
      */
     @JsonProperty(PointSelector.T_COORDINATE)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Float> getSeconds() {
         return myT;
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/AuthTokenService1.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/AuthTokenService1.java
@@ -104,6 +104,7 @@ public class AuthTokenService1 extends AbstractAuthService<AuthTokenService1>
     }
 
     @Override
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Service.Profile> getProfile() {
         return super.getProfile();
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/ClickthroughCookieService1.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/ClickthroughCookieService1.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -159,6 +161,7 @@ public class ClickthroughCookieService1 extends UserMediatedCookieService1<Click
      * @return The service profile
      */
     @Override
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Service.Profile> getProfile() {
         return super.getProfile();
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/ExternalCookieService1.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/ExternalCookieService1.java
@@ -5,6 +5,8 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import info.freelibrary.util.Logger;
@@ -129,6 +131,7 @@ public class ExternalCookieService1 extends AbstractCookieService<ExternalCookie
      * @return The service profile
      */
     @Override
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Service.Profile> getProfile() {
         return super.getProfile();
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService2.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService2.java
@@ -167,6 +167,7 @@ public class ImageService2 extends AbstractImageService<ImageService2> implement
 
     @Override
     @JsonGetter(JsonKeys.PROFILE)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Service.Profile> getProfile() {
         return super.getProfile();
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService3.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/ImageService3.java
@@ -167,6 +167,7 @@ public class ImageService3 extends AbstractImageService<ImageService3> implement
 
     @Override
     @JsonGetter(JsonKeys.PROFILE)
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Service.Profile> getProfile() {
         return super.getProfile();
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/KioskCookieService1.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/KioskCookieService1.java
@@ -5,6 +5,8 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import info.freelibrary.util.Logger;
@@ -151,6 +153,7 @@ public class KioskCookieService1 extends AbstractCookieService<KioskCookieServic
      * @return The service profile
      */
     @Override
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Service.Profile> getProfile() {
         return super.getProfile();
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/services/LoginCookieService1.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/services/LoginCookieService1.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -158,6 +160,7 @@ public class LoginCookieService1 extends UserMediatedCookieService1<LoginCookieS
      * @return The service profile
      */
     @Override
+    @JsonInclude(Include.NON_ABSENT)
     public Optional<Service.Profile> getProfile() {
         return super.getProfile();
     }

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/JSON.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/JSON.java
@@ -32,9 +32,8 @@ public final class JSON {
      */
     private static final ObjectMapper MAPPER = new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, true)
             .configure(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true)
-            .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)
-            .registerModules(new Jdk8Module().configureAbsentsAsNulls(true),
-                    new SimpleModule().addSerializer(float.class, new JSON().new FloatSerializer()));
+            .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true).registerModules(
+                    new Jdk8Module(), new SimpleModule().addSerializer(float.class, new JSON().new FloatSerializer()));
 
     /**
      * Creates a new (de)serialization configuration.


### PR DESCRIPTION
This supports people using Jackson serialization in other ways than the `toString()` method.