### PR TITLE
Fix CLI host handling

### DIFF
--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3.java
@@ -107,7 +107,7 @@ public final class JPv3 implements Callable<Integer> {
         if ((myAction.myUploadFlag || myAction.myPatchFlag) && (StringUtils.trimToNull(myUsername) == null ||
                 StringUtils.trimToNull(myPassword) == null || myHost == null)) {
             throw new CommandLine.ParameterException(new CommandLine(this),
-                    LOGGER.getMessage(MessageCodes.JPA_174, Constants.EOL));
+              LOGGER.getMessage(MessageCodes.JPA_174, Constants.EOL));
         }
 
         try {
@@ -128,8 +128,8 @@ public final class JPv3 implements Callable<Integer> {
                     final String basicAuth = "Basic " + Base64.getEncoder().encodeToString(credentials);
                     final HttpRequest.BodyPublisher bodyPublisher = HttpRequest.BodyPublishers.ofFile(myOutputFile);
                     final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(myHost)
-                            .header(HTTP.Header.CONTENT_TYPE, MediaType.APPLICATION_ZIP.toString())
-                            .header(HTTP.Header.AUTHORIZATION, basicAuth);
+                      .header(HTTP.Header.CONTENT_TYPE, MediaType.APPLICATION_ZIP.toString())
+                      .header(HTTP.Header.AUTHORIZATION, basicAuth);
                     final HttpResponse<String> response;
                     final HttpRequest request;
                     final int statusCode;

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3.java
@@ -112,7 +112,7 @@ public final class JPv3 implements Callable<Integer> {
 
         try {
             // Map the CSV file(s) to JSON manifests and collection documents
-            final int result = new Mapper(Stream.of(myInputFile), myOutputFile).map();
+            final int result = new Mapper(Stream.of(myInputFile), myOutputFile).map(myHost);
 
             // If the mapping was unsuccessful, we can bail here; nothing else needs to happen
             if (result != 0) {

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/csv/Builder.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/csv/Builder.java
@@ -27,6 +27,7 @@ import info.freelibrary.util.ThrowingFunction;
 import info.freelibrary.util.warnings.JDK;
 import info.freelibrary.util.warnings.PMD;
 
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -34,9 +35,32 @@ import java.util.Optional;
 /** A IIIF builder for CSV-based deserialization. */
 public class Builder {
 
+    /** The server to which the built resources will be published. */
+    private URI myServer;
+
     /** Creates a new builder. */
     public Builder() {
-        // This is intentionally empty
+        // This is intentionally left empty
+    }
+
+    /**
+     * Sets the server to which the built resources will be published.
+     *
+     * @param aServer The server URI
+     * @return This builder instance for method chaining
+     */
+    public Builder setServer(final URI aServer) {
+        myServer = aServer;
+        return this;
+    }
+
+    /**
+     * Gets the server to which the built resources will be published.
+     *
+     * @return The server URI
+     */
+    public URI getServer() {
+        return myServer;
     }
 
     /**
@@ -128,10 +152,11 @@ public class Builder {
      * @return The modified or original ID string, depending on the logic
      * @throws MappingException If an error occurs during processing
      */
+    @SuppressWarnings({ "PMD.CyclomaticComplexity" })
     public String checkID(final String aID, final String aResourceType) throws MappingException {
         // If the ID starts with a "https://", we assume it's already formatted correctly; else, we do it
         if (!aID.startsWith("https://")) {
-            final String host = Env.get(Configs.JPV3_HOST, "https://localhost:9999");
+            final String host = myServer != null ? myServer.toString() : "https://localhost:9999";
             final String urlTemplate;
 
             switch (aResourceType) {

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/csv/Mapper.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/csv/Mapper.java
@@ -29,6 +29,7 @@ import org.mapdb.HTreeMap;
 import org.mapdb.Serializer;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -149,21 +150,24 @@ public class Mapper {
     /**
      * Gets the result of the mapping.
      *
+     * @param aServer The server to which the mapped data will be published
      * @return The result of the mapping
      * @throws MappingException If there is trouble mapping the CSV data
      * @throws IOException If there is trouble reading the CSV file
      */
-    public int map() throws MappingException, IOException {
+    public int map(final URI aServer) throws MappingException, IOException {
         final List<String> collections = myObjTypes.getOrDefault(Keys.COLLECTION, Set.of()).stream()
                 .filter(id -> !myChildren.contains(id)).toList();
         final int result;
+
+        myBuilder.setServer(aServer);
 
         // Check to see if our CSV data has any collections, our highest level in the hierarchy
         if (!collections.isEmpty()) {
             result = mapCollections(collections).toFile().exists() ? 0 : -1;
         } else {
             final List<String> works = myObjTypes.getOrDefault(Keys.WORK, Set.of()).stream().toList();
-            result = !works.isEmpty() ? 0 : -1;
+            result = !works.isEmpty() ? 0 : -1; // FIXME
         }
 
         close();

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
@@ -46,11 +46,10 @@ public class JPv3UtilsTest {
         final Path source = Path.of("src/test/resources/zip/nested.zip");
         final Path target = Path.of(TARGET, "nested.zip");
         final List<String> expected = List.of("nested/collection/jbu-2-collection.csv",
-            "nested/layers/jbu-2-layers.csv", "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv").stream()
-          .map(Path::of).map(Path::toString).collect(Collectors.toList());
+            "nested/layers/jbu-2-layers.csv", "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv");
 
         JPv3Utils.outputZipFile(source, target, HOST);
-        checkZipEntries(target, expected);
+        checkZipEntries(target, expected.stream().map(Path::of).map(Path::toString).collect(Collectors.toList()));
     }
 
     /**

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
@@ -1,3 +1,4 @@
+
 package info.freelibrary.iiif.presentation.v3.utils.cmdline;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
@@ -46,7 +46,7 @@ public class JPv3UtilsTest {
         final Path source = Path.of("src/test/resources/zip/nested.zip");
         final Path target = Path.of(TARGET, "nested.zip");
         final List<String> expected = List.of("nested/collection/jbu-2-collection.csv",
-            "nested/layers/jbu-2-layers.csv", "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv");
+          "nested/layers/jbu-2-layers.csv", "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv");
 
         JPv3Utils.outputZipFile(source, target, HOST);
         checkZipEntries(target, expected.stream().map(Path::of).map(Path::toString).collect(Collectors.toList()));
@@ -62,8 +62,8 @@ public class JPv3UtilsTest {
         final String source = StringUtils.read(new File("src/test/resources/csv/jbu-collection.csv"));
         final List<String> actual = JPv3Utils.readHeaders(source);
         final List<String> expected = List.of("File Name", "Object Type", "Title", "Item Sequence", "Item ARK",
-          "Parent ARK", "IIIF target", "viewingHint", "Text direction", "Bucketeer state", "Thumbnail", "media.height",
-          "media.width", "IIIF Access URL", "NOTES");
+          "Parent ARK", "IIIF target", "viewingHint", "Text direction", "Bucketeer state", "Thumbnail",
+          "media.height", "media.width", "IIIF Access URL", "NOTES");
 
         assertEquals(expected, actual);
     }
@@ -79,8 +79,7 @@ public class JPv3UtilsTest {
         final List<String> entryNames;
 
         try (ZipFile zipFile = new ZipFile(aZipPath.toFile())) {
-            entryNames = zipFile.stream().filter(entry -> !entry.isDirectory()).map(ZipEntry::getName).collect(
-              Collectors.toList());
+            entryNames = zipFile.stream().filter(entry -> !entry.isDirectory()).map(ZipEntry::getName).toList();
         }
 
         assertEquals(aExpectedList, entryNames);

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
@@ -1,4 +1,3 @@
-
 package info.freelibrary.iiif.presentation.v3.utils.cmdline;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/csv/BuilderTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/csv/BuilderTest.java
@@ -8,6 +8,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
@@ -19,6 +20,9 @@ public class BuilderTest {
 
     /** The CSV file to test with. */
     private static final Path CSV_FILE = Path.of("src/test/resources/csv/jbu-collection.csv");
+
+    /** The server to test with. We're not sending anything, so okay to use production. */
+    private static final URI SERVER = URI.create("https://iiif.library.ucla.edu");
 
     /** The CSV data to test. */
     private Stream<Row> myRows;
@@ -52,7 +56,7 @@ public class BuilderTest {
      */
     @Test
     public void testBuild() throws MappingException {
-        final Collection collection = new Builder().build(myRows.findFirst().orElseThrow());
+        final Collection collection = new Builder().setServer(SERVER).build(myRows.findFirst().orElseThrow());
         final String expected = """
             {
               "@context" : "http://iiif.io/api/presentation/3/context.json",

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/csv/CsvSourcesTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/csv/CsvSourcesTest.java
@@ -1,3 +1,4 @@
+
 package info.freelibrary.iiif.presentation.v3.utils.csv;
 
 import static info.freelibrary.util.Constants.SLASH;

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/csv/CsvSourcesTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/csv/CsvSourcesTest.java
@@ -1,4 +1,3 @@
-
 package info.freelibrary.iiif.presentation.v3.utils.csv;
 
 import static info.freelibrary.util.Constants.SLASH;

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/csv/MapperTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/csv/MapperTest.java
@@ -16,6 +16,7 @@ import org.junit.rules.TestName;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -56,6 +57,9 @@ public class MapperTest {
     /** A directory containing JSON files corresponding to multipart CSV files. */
     private static final String EXPECTED_RESULTS = "src/test/resources/json/multi-part";
 
+    /** The server to test with. */
+    private static final URI SERVER = URI.create("https://iiif.library.ucla.edu");
+
     /** The test's name. */
     @Rule
     public TestName myTestName = new TestName();
@@ -83,7 +87,7 @@ public class MapperTest {
             // Only load the smaller CSV for this test
             return name.endsWith(".csv") && (name.startsWith("accion-") || name.startsWith("lat-"));
         })) {
-            assertEquals(0, new Mapper(fileStream, myZipFile).map());
+            assertEquals(0, new Mapper(fileStream, myZipFile).map(SERVER));
             assertTrue(Files.exists(myZipFile));
 
             // Check that the ZIP file contains the expected JSON files
@@ -107,7 +111,7 @@ public class MapperTest {
     /** Tests that no exception is thrown when the Mapper is initialized. */
     @Test
     public void testMapperInit() throws Exception {
-        final int result = new Mapper(Stream.of(CSV_FILE), myZipFile).map();
+        final int result = new Mapper(Stream.of(CSV_FILE), myZipFile).map(SERVER);
 
         assertEquals(0, result);
         testZipFiles(myZipFile);
@@ -125,7 +129,7 @@ public class MapperTest {
     public void testMapperInitFiles() throws Exception {
         final File dir = new File("src/test/resources/csv");
         final File[] files = FileUtils.listFiles(dir, new RegexFileFilter(".*-2-.*"));
-        final int result = new Mapper(Arrays.stream(files).map(File::toPath), myZipFile).map();
+        final int result = new Mapper(Arrays.stream(files).map(File::toPath), myZipFile).map(SERVER);
 
         assertEquals(0, result);
         testZipFiles(myZipFile);
@@ -159,6 +163,6 @@ public class MapperTest {
      * @return The ID with replacements applied
      */
     private String replaceIDs(final String aID) {
-        return aID.replaceAll(REPLACED_ID, REPLACE_ID);
+        return aID.replaceAll(REPLACED_ID, REPLACE_ID).replaceAll("\"(https://localhost:9999/[^\"]*)\"", REPLACE_ID);
     }
 }


### PR DESCRIPTION
The host was being pulled from the ENV, which doesn't work (obv) when the arg was passed on the command line. This PR uses the CLI arg parsing to set the host in the builder, so that it can be used in ID construction.

* Fix host handling
* Make separators platform-independent in tests
* Make a few minor formatting tweaks