### PR TITLE
Modify ingest host for prod

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,10 +247,10 @@
             </plugin>
 
             <!-- The rules need to be updated to fit some IDEA changes -->
-            <!--<plugin>
+            <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>-->
+            </plugin>
 
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3.java
@@ -2,6 +2,7 @@
 package info.freelibrary.iiif.presentation.v3.utils.cmdline;
 
 import static info.freelibrary.util.Constants.COLON;
+import static info.freelibrary.util.Constants.EMPTY;
 
 import info.freelibrary.iiif.presentation.v3.properties.MediaType;
 import info.freelibrary.iiif.presentation.v3.utils.MessageCodes;
@@ -30,8 +31,11 @@ import java.util.stream.Stream;
 
 /** A jpv3 executable. */
 @CommandLine.Command(name = "jpv3", version = "jpv3 0.0.1-SNAPSHOT", usageHelpWidth = 120,
-        description = { "", "A tool for working with IIIF manifests and collection documents:", "" })
+        description = { EMPTY, "A tool for working with IIIF manifests and collection documents:", EMPTY })
 public final class JPv3 implements Callable<Integer> {
+
+    /** The expected prefix for the IIIF manifests and collection documents server. */
+    public static final String ENDPOINT_PREFIX = "ingest";
 
     /** The logger for the executable. */
     private static final Logger LOGGER = LoggerFactory.getLogger(JPv3.class, MessageCodes.BUNDLE);
@@ -128,11 +132,14 @@ public final class JPv3 implements Callable<Integer> {
                 final String csvZipFileName = FileUtils.stripExt(myOutputFile.getFileName().toString()) + "-csv.zip";
                 final Path csvZipFile = Path.of(myOutputFile.getParent().toString(), csvZipFileName);
 
+                // We make some assumptions about manifest server endpoints: the upload endpoint must contain `ingest`
+                final URI host = myHost.toString().contains(ENDPOINT_PREFIX) ? myHost : JPv3Utils.updateHost(myHost);
+
                 try (HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()) {
                     final byte[] credentials = (myUsername + COLON + myPassword).getBytes(StandardCharsets.UTF_8);
                     final String basicAuth = "Basic " + Base64.getEncoder().encodeToString(credentials);
                     final HttpRequest.BodyPublisher bodyPublisher = HttpRequest.BodyPublishers.ofFile(myOutputFile);
-                    final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(myHost)
+                    final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(host)
                             .header(HTTP.Header.CONTENT_TYPE, MediaType.APPLICATION_ZIP.toString())
                             .header(HTTP.Header.AUTHORIZATION, basicAuth);
                     final HttpResponse<String> response;

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3Utils.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3Utils.java
@@ -1,6 +1,7 @@
 
 package info.freelibrary.iiif.presentation.v3.utils.cmdline;
 
+import static info.freelibrary.iiif.presentation.v3.utils.cmdline.JPv3.ENDPOINT_PREFIX;
 import static info.freelibrary.util.Constants.EMPTY;
 import static info.freelibrary.util.Constants.PERIOD;
 import static info.freelibrary.util.Constants.SLASH;
@@ -39,6 +40,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -109,6 +111,32 @@ public final class JPv3Utils {
     }
 
     /**
+     * Updates the host of a URI with an `ingest` endpoint prefix, if necessary.
+     *
+     * @param aURI A URI to update with the endpoint prefix
+     * @return The updated URI
+     * @throws IllegalArgumentI18nException If the URI doesn't have a host
+     */
+    public static URI updateHost(final URI aURI) {
+        final String host = aURI.getHost();
+        final String ingestHost;
+
+        if (host == null) {
+            throw new IllegalArgumentI18nException(MessageCodes.BUNDLE, MessageCodes.JPA_190, aURI);
+        }
+
+        // Add an `ingest` endpoint prefix to the front of the host if it doesn't already have one
+        ingestHost = !host.contains(ENDPOINT_PREFIX + PERIOD) ? ENDPOINT_PREFIX + PERIOD + host : host;
+
+        try {
+            return new URI(aURI.getScheme(), aURI.getUserInfo(), ingestHost, aURI.getPort(), aURI.getPath(),
+                    aURI.getQuery(), aURI.getFragment());
+        } catch (final URISyntaxException details) {
+            throw new IllegalArgumentI18nException(details, details.getMessage());
+        }
+    }
+
+    /**
      * Sets the default log level for the supplied logger's root logger.
      *
      * @param aLogger The logger on which to set the supplied level
@@ -160,8 +188,8 @@ public final class JPv3Utils {
      * @param aSourceFile A location of source file(s)
      * @param aOutputFile An output ZIP file
      * @param aHost A host URI for the IIIF Presentation files
-     * @throws IOException If there is trouble writing the ZIP file
      * @return An exit code (0 for success)
+     * @throws IOException If there is trouble writing the ZIP file
      */
     public static int outputZipFile(final Path aSourceFile, final Path aOutputFile, final URI aHost)
             throws IOException {

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/csv/CsvSources.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/csv/CsvSources.java
@@ -80,7 +80,7 @@ public class CsvSources implements Iterable<Path> {
      * @return The temporary directory used for CSV processing
      */
     public Optional<Path> getTempDir() {
-        return Optional.of(myTmpDir);
+        return Optional.ofNullable(myTmpDir);
     }
 
     @Override

--- a/src/main/resources/iiif_presentation_messages.xml
+++ b/src/main/resources/iiif_presentation_messages.xml
@@ -168,4 +168,6 @@
     <entry key="JPA-187">Failed to process ZIP archive: {}</entry>
     <entry key="JPA-188">Failed to copy: {} -> {}</entry>
     <entry key="JPA-189">Updated CSV source file(s): {}</entry>
+    <entry key="JPA-190">URI endpoint has no host: {}</entry>
+    <entry key="JPA-191">Failed to create temporary directory for CSV processing</entry>
 </properties>

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
@@ -1,3 +1,4 @@
+
 package info.freelibrary.iiif.presentation.v3.utils.cmdline;
 
 import static org.junit.Assert.assertEquals;
@@ -46,10 +47,21 @@ public class JPv3UtilsTest {
         final Path source = Path.of("src/test/resources/zip/nested.zip");
         final Path target = Path.of(TARGET, "nested.zip");
         final List<String> expected = List.of("nested/collection/jbu-2-collection.csv",
-          "nested/layers/jbu-2-layers.csv", "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv");
+                "nested/layers/jbu-2-layers.csv", "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv");
 
         JPv3Utils.outputZipFile(source, target, HOST);
         checkZipEntries(target, expected.stream().map(Path::of).map(Path::toString).collect(Collectors.toList()));
+    }
+
+    /**
+     * Tests the updateHost method of JPv3Utils.
+     */
+    @Test
+    public void testUpdateHost() {
+        final URI host = JPv3Utils.updateHost(URI.create("https://iiif.library.ucla.edu"));
+
+        assertEquals(URI.create("https://ingest.iiif.library.ucla.edu"), host);
+        assertEquals(HOST, JPv3Utils.updateHost(HOST));
     }
 
     /**
@@ -62,8 +74,8 @@ public class JPv3UtilsTest {
         final String source = StringUtils.read(new File("src/test/resources/csv/jbu-collection.csv"));
         final List<String> actual = JPv3Utils.readHeaders(source);
         final List<String> expected = List.of("File Name", "Object Type", "Title", "Item Sequence", "Item ARK",
-          "Parent ARK", "IIIF target", "viewingHint", "Text direction", "Bucketeer state", "Thumbnail",
-          "media.height", "media.width", "IIIF Access URL", "NOTES");
+                "Parent ARK", "IIIF target", "viewingHint", "Text direction", "Bucketeer state", "Thumbnail",
+                "media.height", "media.width", "IIIF Access URL", "NOTES");
 
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
* Add `ingest` to manifest endpoint if it's not already in the host URI
* Fighting with the JetBrains formatter and the Maven formatter plugin (so some meaningless syntactical updates)
* Fix a NPE related to the tmpDir and uploading CSVs from the file system