### PR TITLE
[DLSR-327] Fix internal CSV ZIP file paths

### DIFF
--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3Utils.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3Utils.java
@@ -29,14 +29,17 @@ import info.freelibrary.iiif.presentation.v3.utils.MessageCodes;
 import info.freelibrary.iiif.presentation.v3.utils.csv.CsvSources;
 import info.freelibrary.iiif.presentation.v3.utils.csv.Keys;
 import info.freelibrary.iiif.presentation.v3.utils.csv.ZipWriter;
+import info.freelibrary.util.FileUtils;
 import info.freelibrary.util.IllegalArgumentI18nException;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
 import info.freelibrary.util.warnings.Checkstyle;
 import info.freelibrary.util.warnings.PMD;
+import org.jspecify.annotations.NonNull;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -202,21 +205,48 @@ public final class JPv3Utils {
                 final String csvPath = path.toString();
                 final String csvData = updateCSV(contents, aHost.toString());
 
+                // If tmpDirOpt is present, we're working with a ZIP file
                 if (tmpDirOpt.isPresent()) {
-                    final String tmpDirPath = tmpDirOpt.get().toString();
+                    final Path tmpDirPath = tmpDirOpt.get();
 
-                    if (csvPath.startsWith(tmpDirPath)) {
-                        zipWriter.writeFile(csvPath.substring(tmpDirPath.length() + 1), csvData);
+                    if (csvPath.startsWith(tmpDirPath.toString())) {
+                        final String parentPath = getPathParent(aOutputFile);
+                        final String filePath = getZipFilePath(path, tmpDirPath);
+
+                        zipWriter.writeFile(Path.of(parentPath, filePath).toString(), csvData);
                     } else {
-                        zipWriter.writeFile(csvPath, csvData);
+                        zipWriter.writeFile(stripParentPath(aSourceFile, csvPath), csvData);
                     }
                 } else {
-                    zipWriter.writeFile(csvPath, csvData);
+                    zipWriter.writeFile(stripParentPath(aSourceFile, csvPath), csvData);
                 }
             }));
         }
 
         return 0;
+    }
+
+    /**
+     * Gets the file path within the ZIP archive for a given file path and temporary directory path.
+     *
+     * @param aPath The file path
+     * @param aTmpDirPath The temporary directory path
+     * @return The file path within the ZIP archive
+     */
+    private static @NonNull String getZipFilePath(final Path aPath, final Path aTmpDirPath) {
+        final Path zipPath = aTmpDirPath.relativize(aPath);
+        final String filePath;
+
+        // Check if our ZIP file contained a nested structure or not; if nested, strip first directory
+        if (!zipPath.toString().contains(File.separator)) {
+            filePath = zipPath.toString();
+        } else {
+            // If the ZIP file contains a nested structure, we strip the first path component; this makes the
+            // assumption that nested ZIPs are always created with a parent directory. We could check this?
+            filePath = zipPath.subpath(1, zipPath.getNameCount()).toString();
+        }
+
+        return filePath;
     }
 
     /**
@@ -314,6 +344,45 @@ public final class JPv3Utils {
 
             return headers;
         }
+    }
+
+    /**
+     * Strips a supplied source path from another path.
+     *
+     * @param aSource The source path
+     * @param aPath The path to strip
+     * @return The stripped path
+     */
+    private static String stripParentPath(final Path aSource, final String aPath) {
+        final String sourcePath = aSource.toString();
+
+        if (aPath.startsWith(sourcePath)) {
+            return getPathParent(aSource) + File.separator + aPath.substring(sourcePath.length() + 1);
+        }
+
+        return aPath;
+    }
+
+    /**
+     * Retrieves the parent directory name or the current directory name of the given path.
+     *
+     * @param aPath The {@link Path} to process
+     * @return The name of the parent directory if the path is a file, or the name of the directory itself if the path
+     *         is a directory
+     */
+    private static String getPathParent(final Path aPath) {
+        if (aPath.toFile().isDirectory()) {
+            // Use directory name if the path is a directory
+            return aPath.getFileName().toString();
+        }
+
+        // Use ZIP file name if the path is a ZIP file
+        if (aPath.toString().endsWith(ZIP_EXT)) {
+            return FileUtils.stripExt(aPath.getFileName().toString());
+        }
+
+        // Else, get the parent directory name
+        return aPath.getParent().getFileName().toString();
     }
 
     /**

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
@@ -3,6 +3,7 @@ package info.freelibrary.iiif.presentation.v3.utils.cmdline;
 
 import static org.junit.Assert.assertEquals;
 
+import info.freelibrary.util.Constants;
 import info.freelibrary.util.StringUtils;
 import org.junit.Test;
 
@@ -11,6 +12,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -26,6 +28,26 @@ public class JPv3UtilsTest {
     /** A target directory for testing. */
     private static final String TARGET = "target";
 
+    /** A nested zip file name pattern. */
+    private static final String NESTED_ZIP = "nested{}.zip";
+
+    /** A list of expected nested files. */
+    private static final List<String> EXPECTED_NESTED_FILES = List.of("nested/collection/jbu-2-collection.csv",
+            "nested/layers/jbu-2-layers.csv", "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv");
+
+    /**
+     * Tests the outputZipFile method of JPv3Utils.
+     */
+    @Test
+    public void testOutputZipFileDirs() throws IOException {
+        final Path source = Path.of("src/test/resources/csv/nested");
+        final Path target = Path.of(TARGET, StringUtils.format(NESTED_ZIP,
+            Constants.DASH + UUID.randomUUID().toString()));
+
+        JPv3Utils.outputZipFile(source, target, HOST);
+        checkZipEntries(target, EXPECTED_NESTED_FILES);
+    }
+
     /**
      * Tests the outputZipFile method of JPv3Utils.
      */
@@ -33,7 +55,8 @@ public class JPv3UtilsTest {
     public void testOutputZipFileFlat() throws IOException {
         final Path source = Path.of("src/test/resources/zip/layers-choice.zip");
         final Path target = Path.of(TARGET, "layers-choice.zip");
-        final List<String> expected = List.of("collection.csv", "layers.csv", "pages.csv", "works.csv");
+        final List<String> expected = List.of("layers-choice/collection.csv", "layers-choice/layers.csv",
+                "layers-choice/pages.csv", "layers-choice/works.csv");
 
         JPv3Utils.outputZipFile(source, target, HOST);
         checkZipEntries(target, expected);
@@ -45,12 +68,12 @@ public class JPv3UtilsTest {
     @Test
     public void testOutputZipFileNested() throws IOException {
         final Path source = Path.of("src/test/resources/zip/nested.zip");
-        final Path target = Path.of(TARGET, "nested.zip");
-        final List<String> expected = List.of("nested/collection/jbu-2-collection.csv",
-                "nested/layers/jbu-2-layers.csv", "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv");
+        final Path target = Path.of(TARGET, StringUtils.format(NESTED_ZIP, Constants.EMPTY));
+        final List<String> expected = // Stream to handle OS-specific file separators correctly
+                EXPECTED_NESTED_FILES.stream().map(Path::of).map(Path::toString).collect(Collectors.toList());
 
         JPv3Utils.outputZipFile(source, target, HOST);
-        checkZipEntries(target, expected.stream().map(Path::of).map(Path::toString).collect(Collectors.toList()));
+        checkZipEntries(target, expected);
     }
 
     /**

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
@@ -32,10 +32,9 @@ public class JPv3UtilsTest {
     private static final String NESTED_ZIP = "nested{}.zip";
 
     /** A list of expected nested files. */
-    private static final List<String> EXPECTED_NESTED_FILES = Stream
-            .of("nested/collection/jbu-2-collection.csv", "nested/layers/jbu-2-layers.csv",
-                    "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv")
-            .map(Path::of).map(Path::toString).toList();
+    private static final List<String> EXPECTED_NESTED_FILES = Stream.of("nested/collection/jbu-2-collection.csv",
+        "nested/layers/jbu-2-layers.csv", "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv")
+        .map(Path::of).map(Path::toString).toList();
 
     /**
      * Tests the outputZipFile method of JPv3Utils.
@@ -57,8 +56,8 @@ public class JPv3UtilsTest {
     public void testOutputZipFileFlat() throws IOException {
         final Path source = Path.of("src/test/resources/zip/layers-choice.zip");
         final Path target = Path.of(TARGET, "layers-choice.zip");
-        final List<String> expected = List.of("layers-choice/collection.csv", "layers-choice/layers.csv",
-                "layers-choice/pages.csv", "layers-choice/works.csv");
+        final List<String> expected = Stream.of("layers-choice/collection.csv", "layers-choice/layers.csv",
+            "layers-choice/pages.csv", "layers-choice/works.csv").map(Path::of).map(Path::toString).toList();
 
         JPv3Utils.outputZipFile(source, target, HOST);
         checkZipEntries(target, expected);
@@ -97,8 +96,8 @@ public class JPv3UtilsTest {
         final String source = StringUtils.read(new File("src/test/resources/csv/jbu-collection.csv"));
         final List<String> actual = JPv3Utils.readHeaders(source);
         final List<String> expected = List.of("File Name", "Object Type", "Title", "Item Sequence", "Item ARK",
-                "Parent ARK", "IIIF target", "viewingHint", "Text direction", "Bucketeer state", "Thumbnail",
-                "media.height", "media.width", "IIIF Access URL", "NOTES");
+            "Parent ARK", "IIIF target", "viewingHint", "Text direction", "Bucketeer state", "Thumbnail",
+            "media.height", "media.width", "IIIF Access URL", "NOTES");
 
         assertEquals(expected, actual);
     }

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
@@ -13,7 +13,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -32,8 +32,10 @@ public class JPv3UtilsTest {
     private static final String NESTED_ZIP = "nested{}.zip";
 
     /** A list of expected nested files. */
-    private static final List<String> EXPECTED_NESTED_FILES = List.of("nested/collection/jbu-2-collection.csv",
-            "nested/layers/jbu-2-layers.csv", "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv");
+    private static final List<String> EXPECTED_NESTED_FILES = Stream
+            .of("nested/collection/jbu-2-collection.csv", "nested/layers/jbu-2-layers.csv",
+                    "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv")
+            .map(Path::of).map(Path::toString).toList();
 
     /**
      * Tests the outputZipFile method of JPv3Utils.
@@ -41,8 +43,8 @@ public class JPv3UtilsTest {
     @Test
     public void testOutputZipFileDirs() throws IOException {
         final Path source = Path.of("src/test/resources/csv/nested");
-        final Path target = Path.of(TARGET, StringUtils.format(NESTED_ZIP,
-            Constants.DASH + UUID.randomUUID().toString()));
+        final String zipFile = StringUtils.format(NESTED_ZIP, Constants.DASH + UUID.randomUUID().toString());
+        final Path target = Path.of(TARGET, zipFile);
 
         JPv3Utils.outputZipFile(source, target, HOST);
         checkZipEntries(target, EXPECTED_NESTED_FILES);
@@ -69,11 +71,9 @@ public class JPv3UtilsTest {
     public void testOutputZipFileNested() throws IOException {
         final Path source = Path.of("src/test/resources/zip/nested.zip");
         final Path target = Path.of(TARGET, StringUtils.format(NESTED_ZIP, Constants.EMPTY));
-        final List<String> expected = // Stream to handle OS-specific file separators correctly
-                EXPECTED_NESTED_FILES.stream().map(Path::of).map(Path::toString).collect(Collectors.toList());
 
         JPv3Utils.outputZipFile(source, target, HOST);
-        checkZipEntries(target, expected);
+        checkZipEntries(target, EXPECTED_NESTED_FILES);
     }
 
     /**


### PR DESCRIPTION
Fix ZIP file paths so they start at the ZIP file root, rather than include user file system paths.