### PR TITLE
[DLSR-330] Rename IIIF image server ENV property

### DIFF
--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3.java
@@ -66,12 +66,12 @@ public final class JPv3 implements Callable<Integer> {
 
     /** The IIIF manifests and collection documents server. */
     @CommandLine.Option(names = { "-H", "--host" }, description = "The IIIF manifests and collection documents server",
-            paramLabel = "HOST", defaultValue = "${env:JPV3_HOST}", required = true)
+            paramLabel = "HOST_URL", defaultValue = "${env:JPV3_HOST}", required = true)
     private URI myHost;
 
     /** The IIIF images server. */
-    @CommandLine.Option(names = { "-I", "--iiif" }, description = "The URL of the server that has the IIIF images",
-            paramLabel = "IIIF_SERVER", defaultValue = "${env:JPV3_IIIF_SERVER}", required = true)
+    @CommandLine.Option(names = { "-I", "--images" }, description = "The URL of the server that has the IIIF images",
+            paramLabel = "IMAGE_SERVER_URL", defaultValue = "${env:JPV3_IMAGE_SERVER}", required = true)
     private URI myImageServer;
 
     /** The help flag. */

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/csv/README.md
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/csv/README.md
@@ -15,8 +15,8 @@ quick overview, not a comprehensive guide.
 ### Getting Started
 
 Before running the program, there are two environment variables that need to be set:
-* `JPV3_HOST`
-* `JPV3_IIIF_SERVER`
+* `JPV3_HOST` # This should be the URL of the IIIF manifest server
+* `JPV3_IMAGE_SERVER` # This should be the URL of the IIIF image server
 
 For UCLA users testing the application, the values for these should be `https://test.ingest.iiif.library.ucla.edu` and
 `https://iiif.library.ucla.edu/iiif/2`. Both variables are required to create manifest and image links in the generated 


### PR DESCRIPTION
Rename in the image server ENV property so that there is a clear distinction between IIIF image server and IIIF manifest server configurations.