### PR TITLE
[DLSR-328] Add custom output file name option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@ docs/.env
 jiiify-presentation-v3.iml
 
 # Output of native builds
-output.zip
-output.csv.zip
+outpu*.zip

--- a/pom.xml
+++ b/pom.xml
@@ -396,6 +396,22 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <!-- In case someone runs the program from the basedir -->
+                                    <directory>.</directory>
+                                    <includes>
+                                        <include>*.zip</include>
+                                    </includes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
                         <executions>
                             <execution>

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3.java
@@ -45,10 +45,9 @@ public final class JPv3 implements Callable<Integer> {
             paramLabel = "INPUT", required = true)
     private Path myInputFile;
 
-    /** The output file. */
-    @CommandLine.Option(names = { "-o", "--output" }, defaultValue = "./output.zip", paramLabel = "OUTPUT",
-            showDefaultValue = CommandLine.Help.Visibility.ALWAYS, description = "An output file to be written")
-    private Path myOutputFile;
+    /** The output file options group. */
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "0..1")
+    private final OutputOptions myOutputOpts = new OutputOptions();
 
     /** The action to take. Only one is allowed for a given invocation. */
     @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
@@ -120,17 +119,19 @@ public final class JPv3 implements Callable<Integer> {
         }
 
         try {
-            // Map the CSV file(s) to JSON manifests and collection documents
-            final int result = new Mapper(Stream.of(myInputFile), myOutputFile).map(myHost, myImageServer);
+            final Path outputFile = myOutputOpts.getOutputFile(myInputFile);
 
-            // If the mapping was unsuccessful, we can bail here; nothing else needs to happen
+            // Map the CSV file(s) to JSON manifests and collection documents
+            final int result = new Mapper(Stream.of(myInputFile), outputFile).map(myHost, myImageServer);
+
+            // If the mapping was unsuccessful, we can bail; nothing else needs to happen
             if (result != 0) {
                 return result;
             }
 
             if (myAction.isUpload() || myAction.isPatch()) {
-                final String csvZipFileName = FileUtils.stripExt(myOutputFile.getFileName().toString()) + "-csv.zip";
-                final Path csvZipFile = Path.of(myOutputFile.getParent().toString(), csvZipFileName);
+                final String csvZipFileName = FileUtils.stripExt(outputFile.getFileName().toString()) + "-csv.zip";
+                final Path csvZipFile = Path.of(EMPTY).resolve(csvZipFileName); // Puts file into current directory
 
                 // We make some assumptions about manifest server endpoints: the upload endpoint must contain `ingest`
                 final URI host = myHost.toString().contains(ENDPOINT_PREFIX) ? myHost : JPv3Utils.updateHost(myHost);
@@ -138,13 +139,11 @@ public final class JPv3 implements Callable<Integer> {
                 try (HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()) {
                     final byte[] credentials = (myUsername + COLON + myPassword).getBytes(StandardCharsets.UTF_8);
                     final String basicAuth = "Basic " + Base64.getEncoder().encodeToString(credentials);
-                    final HttpRequest.BodyPublisher bodyPublisher = HttpRequest.BodyPublishers.ofFile(myOutputFile);
+                    final HttpRequest.BodyPublisher bodyPublisher = HttpRequest.BodyPublishers.ofFile(outputFile);
                     final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(host)
                             .header(HTTP.Header.CONTENT_TYPE, MediaType.APPLICATION_ZIP.toString())
                             .header(HTTP.Header.AUTHORIZATION, basicAuth);
-                    final HttpResponse<String> response;
                     final HttpRequest request;
-                    final int statusCode;
 
                     if (myAction.isPatch()) {
                         request = builder.method(HTTP.Method.PATCH, bodyPublisher).build();
@@ -152,21 +151,21 @@ public final class JPv3 implements Callable<Integer> {
                         request = builder.POST(bodyPublisher).build();
                     }
 
-                    response = client.send(request, HttpResponse.BodyHandlers.ofString());
-                    statusCode = response.statusCode();
+                    final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                    final int statusCode = response.statusCode();
 
                     if (statusCode != HTTP.OK && statusCode != HTTP.CREATED) {
                         LOGGER.error(LOGGER.getMessage(MessageCodes.JPA_177, statusCode, response.body()));
                         return statusCode;
                     }
 
-                    LOGGER.info(LOGGER.getMessage(MessageCodes.JPA_180, myOutputFile.toAbsolutePath()));
+                    LOGGER.info(LOGGER.getMessage(MessageCodes.JPA_180, outputFile));
                 }
 
                 LOGGER.info(LOGGER.getMessage(MessageCodes.JPA_189, csvZipFile));
                 return JPv3Utils.outputZipFile(myInputFile, csvZipFile, myHost);
             } else if (myAction.isCreate()) {
-                LOGGER.info(LOGGER.getMessage(MessageCodes.JPA_178, myOutputFile.toAbsolutePath()));
+                LOGGER.info(LOGGER.getMessage(MessageCodes.JPA_178, outputFile.toAbsolutePath()));
                 return 0;
             } else if (myAction.isView()) {
                 LOGGER.info(LOGGER.getMessage(MessageCodes.JPA_179));
@@ -180,8 +179,35 @@ public final class JPv3 implements Callable<Integer> {
         }
     }
 
+    /** The output options for the jpv3 program. */
+    private static final class OutputOptions {
+
+        /** The standard output file mechanism. */
+        @CommandLine.Option(names = { "-o", "--output" }, defaultValue = "./output.zip", paramLabel = "OUTPUT",
+                showDefaultValue = CommandLine.Help.Visibility.ALWAYS, description = "An output file to be written")
+        private Path myOutputFile;
+
+        /** A customized default output file name. */
+        @CommandLine.Option(names = { "-O" }, description = "Create an output file based on the input file name")
+        private boolean isCustomOutputFile;
+
+        /**
+         * Gets the output file path based on the input file and user options.
+         *
+         * @param aInputFile The input file path
+         * @return The output file path
+         */
+        private Path getOutputFile(final Path aInputFile) {
+            if (isCustomOutputFile) {
+                return JPv3Utils.getCustomOutputPath(aInputFile);
+            }
+
+            return myOutputFile;
+        }
+    }
+
     /** The action for the jpv3 program to take. */
-    static class Action {
+    private static final class Action {
 
         /** Whether to create a local manifest or collection doc. */
         @CommandLine.Option(names = { "-c", "--create" }, description = "Create a local zip with IIIF resources")

--- a/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3Utils.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3Utils.java
@@ -162,6 +162,16 @@ public final class JPv3Utils {
     }
 
     /**
+     * Returns a custom output path based on the input file path.
+     *
+     * @param aInputFile The input file path
+     * @return The custom output path
+     */
+    public static Path getCustomOutputPath(final Path aInputFile) {
+        return Path.of(EMPTY).resolve("output-" + getPathParent(aInputFile) + ZIP_EXT);
+    }
+
+    /**
      * Quickly finds a JSON property value.
      *
      * @param aFilePath A path to a JSON file
@@ -357,18 +367,18 @@ public final class JPv3Utils {
         final String sourcePath = aSource.toString();
 
         if (aPath.startsWith(sourcePath)) {
-            return getPathParent(aSource) + File.separator + aPath.substring(sourcePath.length() + 1);
+            return Path.of(getPathParent(aSource)).resolve(aSource.relativize(Path.of(aPath))).toString();
         }
 
         return aPath;
     }
 
     /**
-     * Retrieves the parent directory name or the current directory name of the given path.
+     * Retrieves what will be used as the parent directory for a ZIP file or CSV file.
      *
      * @param aPath The {@link Path} to process
-     * @return The name of the parent directory if the path is a file, or the name of the directory itself if the path
-     *         is a directory
+     * @return The name of the parent directory
+     * @throws IllegalArgumentI18nException If the path is not a directory, ZIP file, or CSV file
      */
     private static String getPathParent(final Path aPath) {
         if (aPath.toFile().isDirectory()) {
@@ -377,12 +387,11 @@ public final class JPv3Utils {
         }
 
         // Use ZIP file name if the path is a ZIP file
-        if (aPath.toString().endsWith(ZIP_EXT)) {
+        if (aPath.toString().endsWith(ZIP_EXT) || aPath.toString().endsWith(CSV_EXT)) {
             return FileUtils.stripExt(aPath.getFileName().toString());
         }
 
-        // Else, get the parent directory name
-        return aPath.getParent().getFileName().toString();
+        throw new IllegalArgumentI18nException(MessageCodes.BUNDLE, MessageCodes.JPA_192, aPath);
     }
 
     /**

--- a/src/main/resources/iiif_presentation_messages.xml
+++ b/src/main/resources/iiif_presentation_messages.xml
@@ -170,4 +170,5 @@
     <entry key="JPA-189">Updated CSV source file(s): {}</entry>
     <entry key="JPA-190">URI endpoint has no host: {}</entry>
     <entry key="JPA-191">Failed to create temporary directory for CSV processing</entry>
+    <entry key="JPA-192">Invalid path provided (must be directory, CSV, or ZIP file): {}</entry>
 </properties>

--- a/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/v3/utils/cmdline/JPv3UtilsTest.java
@@ -4,6 +4,7 @@ package info.freelibrary.iiif.presentation.v3.utils.cmdline;
 import static org.junit.Assert.assertEquals;
 
 import info.freelibrary.util.Constants;
+import info.freelibrary.util.IllegalArgumentI18nException;
 import info.freelibrary.util.StringUtils;
 import org.junit.Test;
 
@@ -32,9 +33,10 @@ public class JPv3UtilsTest {
     private static final String NESTED_ZIP = "nested{}.zip";
 
     /** A list of expected nested files. */
-    private static final List<String> EXPECTED_NESTED_FILES = Stream.of("nested/collection/jbu-2-collection.csv",
-        "nested/layers/jbu-2-layers.csv", "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv")
-        .map(Path::of).map(Path::toString).toList();
+    private static final List<String> EXPECTED_NESTED_FILES = Stream
+            .of("nested/collection/jbu-2-collection.csv", "nested/layers/jbu-2-layers.csv",
+                    "nested/pages/jbu-2-pages.csv", "nested/works/jbu-2-works.csv")
+            .map(Path::of).map(Path::toString).toList();
 
     /**
      * Tests the outputZipFile method of JPv3Utils.
@@ -57,7 +59,7 @@ public class JPv3UtilsTest {
         final Path source = Path.of("src/test/resources/zip/layers-choice.zip");
         final Path target = Path.of(TARGET, "layers-choice.zip");
         final List<String> expected = Stream.of("layers-choice/collection.csv", "layers-choice/layers.csv",
-            "layers-choice/pages.csv", "layers-choice/works.csv").map(Path::of).map(Path::toString).toList();
+                "layers-choice/pages.csv", "layers-choice/works.csv").map(Path::of).map(Path::toString).toList();
 
         JPv3Utils.outputZipFile(source, target, HOST);
         checkZipEntries(target, expected);
@@ -73,6 +75,26 @@ public class JPv3UtilsTest {
 
         JPv3Utils.outputZipFile(source, target, HOST);
         checkZipEntries(target, EXPECTED_NESTED_FILES);
+    }
+
+    /**
+     * Tests the getCustomOutputPath method of JPv3Utils.
+     */
+    @Test
+    public void testGetCustomOutputPathZip() {
+        final Path inputPath = Path.of("src/test/resources/zip/package.zip");
+        final Path actual = JPv3Utils.getCustomOutputPath(inputPath);
+        final Path expected = Path.of("output-package.zip");
+
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Tests the getCustomOutputPath method of JPv3Utils.
+     */
+    @Test(expected = IllegalArgumentI18nException.class)
+    public void testGetCustomOutputPathDir() {
+        final Path actual = JPv3Utils.getCustomOutputPath(Path.of("src/test/resources/zip/nested"));
     }
 
     /**
@@ -96,8 +118,8 @@ public class JPv3UtilsTest {
         final String source = StringUtils.read(new File("src/test/resources/csv/jbu-collection.csv"));
         final List<String> actual = JPv3Utils.readHeaders(source);
         final List<String> expected = List.of("File Name", "Object Type", "Title", "Item Sequence", "Item ARK",
-            "Parent ARK", "IIIF target", "viewingHint", "Text direction", "Bucketeer state", "Thumbnail",
-            "media.height", "media.width", "IIIF Access URL", "NOTES");
+                "Parent ARK", "IIIF target", "viewingHint", "Text direction", "Bucketeer state", "Thumbnail",
+                "media.height", "media.width", "IIIF Access URL", "NOTES");
 
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
Support having the output file be named after the program's input file.

* Support a custom output file option
* Add maven clean plugin for zip files generated by the user
* Have `-O` output also go to the current working directory

There are a few code formatting changes as a result of the battle between my Eclipse formatter and IDEA IDE. I need, at some point, to update the formatting rules so they are more like some of the IDEA defaults (which I do like better).